### PR TITLE
Added support for YAML-CPP 0.5+.

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -27,6 +27,10 @@ find_library(YAML_CPP_LIBRARY
              NAMES YAML_CPP
              PATHS ${YAML_CPP_LIBRARY_DIRS})
 
+if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
+
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 catkin_package(


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and
it has a new way of loading documents. There's no version hint in the
library's headers, so I'm getting the version number from pkg-config.

This part of the patch is a port of the ones created by @ktossell for
map_server and other packages.

The new yaml-cpp also uses a different method for loading documents.
