### PR TITLE
support for multiple velodynes

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -57,6 +57,15 @@ namespace velodyne_driver
      *          > 0 if incomplete packet (is this possible?)
      */
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt) = 0;
+
+
+    /** @brief Set source IP, from where packets are accepted
+     *
+     * @param ip IP of a Velodyne LIDAR e.g. 192.168.51.70
+     */
+    virtual void setDeviceIP( const std::string& ip ) { devip_str_ = ip; }
+  protected:
+    std::string devip_str_;
   };
 
   /** @brief Live Velodyne input from socket. */
@@ -68,10 +77,11 @@ namespace velodyne_driver
     ~InputSocket();
 
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt);
-
+    void setDeviceIP( const std::string& ip );
   private:
 
     int sockfd_;
+    in_addr devip_;
   };
 
 
@@ -92,6 +102,7 @@ namespace velodyne_driver
     ~InputPCAP();
 
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt);
+    void setDeviceIP( const std::string& ip );
 
   private:
 
@@ -104,6 +115,7 @@ namespace velodyne_driver
     bool read_fast_;
     double repeat_delay_;
     ros::Rate packet_rate_;
+    bpf_program velodyne_pointdata_filter_;
   };
 
 } // velodyne_driver namespace

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -95,6 +95,12 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
       input_.reset(new velodyne_driver::InputSocket(private_nh));
     }
 
+  std::string devip;
+  private_nh.param("device_ip", devip, std::string(""));
+  if(!devip.empty())
+    ROS_INFO_STREAM("Set device ip to " << devip << ", only accepting packets from this address." );
+  input_->setDeviceIP(devip);
+
   // raw data output topic
   output_ = node.advertise<velodyne_msgs::VelodyneScan>("velodyne_packets", 10);
 }

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -84,6 +84,12 @@ namespace velodyne_driver
     (void) close(sockfd_);
   }
 
+  void InputSocket::setDeviceIP(const std::string &ip)
+  {
+    devip_str_ = ip;
+    inet_aton(ip.c_str(),&devip_);
+  }
+
   /** @brief Get one velodyne packet. */
   int InputSocket::getPacket(velodyne_msgs::VelodynePacket *pkt)
   {
@@ -93,6 +99,9 @@ namespace velodyne_driver
     fds[0].fd = sockfd_;
     fds[0].events = POLLIN;
     static const int POLL_TIMEOUT = 1000; // one second (in msec)
+
+    sockaddr_in sender_address;
+    socklen_t sender_address_len = sizeof(sender_address);
 
     while (true)
       {
@@ -140,7 +149,8 @@ namespace velodyne_driver
         // Receive packets that should now be available from the
         // socket using a blocking read.
         ssize_t nbytes = recvfrom(sockfd_, &pkt->data[0],
-                                  packet_size,  0, NULL, NULL);
+                                  packet_size,  0,
+                                  (sockaddr*) &sender_address, &sender_address_len);
 
 	if (nbytes < 0)
 	  {
@@ -153,8 +163,14 @@ namespace velodyne_driver
 	  }
 	else if ((size_t) nbytes == packet_size)
           {
-            // read successful, done now
-            break;
+            // read successful,
+            // if packet is not from the lidar scanner we selected by IP,
+            // continue otherwise we are done
+        std::cout << sender_address.sin_addr.s_addr << "  " << devip_.s_addr << std::endl;
+            if( devip_str_ != "" && sender_address.sin_addr.s_addr != devip_.s_addr )
+              continue;
+            else
+              break; //done
           }
 
         ROS_DEBUG_STREAM("incomplete Velodyne packet read: "
@@ -225,6 +241,12 @@ namespace velodyne_driver
     pcap_close(pcap_);
   }
 
+  void InputPCAP::setDeviceIP(const std::string &ip)
+  {
+      std::string filter_str = "src host " + devip_str_ + " && udp src port 2368 && udp dst port 2368";
+      if( devip_str_ != "" )
+        pcap_compile(pcap_, &velodyne_pointdata_filter_, filter_str.c_str(), 1, PCAP_NETMASK_UNKNOWN);
+  }
 
   /** @brief Get one velodyne packet. */
   int InputPCAP::getPacket(velodyne_msgs::VelodynePacket *pkt)
@@ -237,6 +259,10 @@ namespace velodyne_driver
         int res;
         if ((res = pcap_next_ex(pcap_, &header, &pkt_data)) >= 0)
           {
+            // if packet is not from the lidar scanner we selected by IP, continue
+            if( !devip_str_.empty() && (pcap_offline_filter( &velodyne_pointdata_filter_, header, pkt_data ) == 0) )
+              continue;
+
             // Keep the reader from blowing through the file.
             if (read_fast_ == false)
               packet_rate_.sleep();

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -166,7 +166,6 @@ namespace velodyne_driver
             // read successful,
             // if packet is not from the lidar scanner we selected by IP,
             // continue otherwise we are done
-        std::cout << sender_address.sin_addr.s_addr << "  " << devip_.s_addr << std::endl;
             if( devip_str_ != "" && sender_address.sin_addr.s_addr != devip_.s_addr )
               continue;
             else


### PR DESCRIPTION
Hello,

we have a scenario here with multiple velodynes in one network. So we developed a patch for your driver, which allows working with multiple velodyne LIDARs.

It adds the parameter "device_ip" to the velodyne_driver node. With the parameter one can select which LIDAR's packets  should be processed and published by the node. Default behaviour is unchanged (process all packets).

Hope you find it useful.
Denis
