### PR TITLE
added model VLP16

### DIFF
--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -49,6 +49,10 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
     {
       packet_rate = 1808.0;
     }
+  else if (config_.model == "VLP16")    // generates ~300000 points per second
+    {                                   // 1 packet holds 384 points (12x32)
+      packet_rate = 781.25;             // 300000 / 384
+    }
   else
     {
       ROS_ERROR_STREAM("unknown Velodyne LIDAR model: " << config_.model);


### PR DESCRIPTION
This PR adds driver support for the new Pucks (VLP-16) lidars. I tested it successfully. Note however that the velodyne_pointcloud node won't work as is. 

On my side I have my own equivalent of the pointcloud node, that I got to work with few modifications. Once/if this PR is merged, I will open an issue to explain how I did it and let someone else implement it.