### PR TITLE
support for multiple velodynes (improved)

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <pcap.h>
+#include <netinet/in.h>
 
 #include <ros/ros.h>
 #include <velodyne_msgs/VelodynePacket.h>

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -57,6 +57,15 @@ namespace velodyne_driver
      *          > 0 if incomplete packet (is this possible?)
      */
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt) = 0;
+
+
+    /** @brief Set source IP, from where packets are accepted
+     *
+     * @param ip IP of a Velodyne LIDAR e.g. 192.168.51.70
+     */
+    virtual void setDeviceIP( const std::string& ip ) { devip_str_ = ip; }
+  protected:
+    std::string devip_str_;
   };
 
   /** @brief Live Velodyne input from socket. */
@@ -68,10 +77,11 @@ namespace velodyne_driver
     ~InputSocket();
 
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt);
-
+    void setDeviceIP( const std::string& ip );
   private:
 
     int sockfd_;
+    in_addr devip_;
   };
 
 
@@ -92,6 +102,7 @@ namespace velodyne_driver
     ~InputPCAP();
 
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt);
+    void setDeviceIP( const std::string& ip );
 
   private:
 
@@ -104,6 +115,7 @@ namespace velodyne_driver
     bool read_fast_;
     double repeat_delay_;
     ros::Rate packet_rate_;
+    bpf_program velodyne_pointdata_filter_;
   };
 
 } // velodyne_driver namespace

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -95,6 +95,12 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
       input_.reset(new velodyne_driver::InputSocket(private_nh));
     }
 
+  std::string devip;
+  private_nh.param("device_ip", devip, std::string(""));
+  if(!devip.empty())
+    ROS_INFO_STREAM("Set device ip to " << devip << ", only accepting packets from this address." );
+  input_->setDeviceIP(devip);
+
   // raw data output topic
   output_ = node.advertise<velodyne_msgs::VelodyneScan>("velodyne_packets", 10);
 }

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -69,6 +69,9 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
   std::string dump_file;
   private_nh.param("pcap", dump_file, std::string(""));
 
+  int udp_port;
+  private_nh.param("port", udp_port, (int)UDP_PORT_NUMBER);
+
   // initialize diagnostics
   diagnostics_.setHardwareID(deviceName);
   const double diag_freq = packet_rate/config_.npackets;
@@ -92,7 +95,7 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
     }
   else
     {
-      input_.reset(new velodyne_driver::InputSocket(private_nh));
+      input_.reset(new velodyne_driver::InputSocket(private_nh, udp_port));
     }
 
   std::string devip;

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -84,6 +84,12 @@ namespace velodyne_driver
     (void) close(sockfd_);
   }
 
+  void InputSocket::setDeviceIP(const std::string &ip)
+  {
+    devip_str_ = ip;
+    inet_aton(ip.c_str(),&devip_);
+  }
+
   /** @brief Get one velodyne packet. */
   int InputSocket::getPacket(velodyne_msgs::VelodynePacket *pkt)
   {
@@ -93,6 +99,9 @@ namespace velodyne_driver
     fds[0].fd = sockfd_;
     fds[0].events = POLLIN;
     static const int POLL_TIMEOUT = 1000; // one second (in msec)
+
+    sockaddr_in sender_address;
+    socklen_t sender_address_len = sizeof(sender_address);
 
     while (true)
       {
@@ -140,7 +149,8 @@ namespace velodyne_driver
         // Receive packets that should now be available from the
         // socket using a blocking read.
         ssize_t nbytes = recvfrom(sockfd_, &pkt->data[0],
-                                  packet_size,  0, NULL, NULL);
+                                  packet_size,  0,
+                                  (sockaddr*) &sender_address, &sender_address_len);
 
 	if (nbytes < 0)
 	  {
@@ -153,8 +163,14 @@ namespace velodyne_driver
 	  }
 	else if ((size_t) nbytes == packet_size)
           {
-            // read successful, done now
-            break;
+            // read successful,
+            // if packet is not from the lidar scanner we selected by IP,
+            // continue otherwise we are done
+        std::cout << sender_address.sin_addr.s_addr << "  " << devip_.s_addr << std::endl;
+            if( devip_str_ != "" && sender_address.sin_addr.s_addr != devip_.s_addr )
+              continue;
+            else
+              break; //done
           }
 
         ROS_DEBUG_STREAM("incomplete Velodyne packet read: "
@@ -225,6 +241,12 @@ namespace velodyne_driver
     pcap_close(pcap_);
   }
 
+  void InputPCAP::setDeviceIP(const std::string &ip)
+  {
+      std::string filter_str = "src host " + devip_str_ + " && udp src port 2368 && udp dst port 2368";
+      if( devip_str_ != "" )
+        pcap_compile(pcap_, &velodyne_pointdata_filter_, filter_str.c_str(), 1, PCAP_NETMASK_UNKNOWN);
+  }
 
   /** @brief Get one velodyne packet. */
   int InputPCAP::getPacket(velodyne_msgs::VelodynePacket *pkt)
@@ -237,6 +259,10 @@ namespace velodyne_driver
         int res;
         if ((res = pcap_next_ex(pcap_, &header, &pkt_data)) >= 0)
           {
+            // if packet is not from the lidar scanner we selected by IP, continue
+            if( !devip_str_.empty() && (pcap_offline_filter( &velodyne_pointdata_filter_, header, pkt_data ) == 0) )
+              continue;
+
             // Keep the reader from blowing through the file.
             if (read_fast_ == false)
               packet_rate_.sleep();

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -166,7 +166,6 @@ namespace velodyne_driver
             // read successful,
             // if packet is not from the lidar scanner we selected by IP,
             // continue otherwise we are done
-        std::cout << sender_address.sin_addr.s_addr << "  " << devip_.s_addr << std::endl;
             if( devip_str_ != "" && sender_address.sin_addr.s_addr != devip_.s_addr )
               continue;
             else

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -152,16 +152,16 @@ namespace velodyne_driver
                                   packet_size,  0,
                                   (sockaddr*) &sender_address, &sender_address_len);
 
-	if (nbytes < 0)
-	  {
+        if (nbytes < 0)
+          {
             if (errno != EWOULDBLOCK)
- 	      {
+              {
                 perror("recvfail");
-		ROS_INFO("recvfail");
+                ROS_INFO("recvfail");
                 return 1;
-	      }
-	  }
-	else if ((size_t) nbytes == packet_size)
+              }
+          }
+        else if ((size_t) nbytes == packet_size)
           {
             // read successful,
             // if packet is not from the lidar scanner we selected by IP,


### PR DESCRIPTION
This is an improvement on @ddillenberger implementation of the multi velodyne support. From what I understand from his design, and from what I experienced today on my setup (4 16-beam velodynes), @ddillenberger code allows to read data from one and only one laser at the same time.

With this pull request, we add support for reading data simultaneously from several lidars at the same time. Each lidar must be configured with a separate IP address and to broadcast on a separate port.

With this code, we were able to read from 4 velodyne at the same time.

Credits also go to @ddillenberger and @ahendrix for this pull request.