### PR TITLE
Add argument for velodyne port number.

### DIFF
--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -11,6 +11,7 @@
         args="manager" />
   <arg name="model" default="64E" />
   <arg name="pcap" default="" />
+  <arg name="port" default="2368" />
   <arg name="read_once" default="false" />
   <arg name="read_fast" default="false" />
   <arg name="repeat_delay" default="0.0" />
@@ -20,6 +21,7 @@
         args="load velodyne_driver/DriverNodelet velodyne_nodelet_manager" >
     <param name="model" value="$(arg model)"/>
     <param name="pcap" value="$(arg pcap)"/>
+    <param name="port" value="$(arg port)"/>
     <param name="read_once" value="$(arg read_once)"/>
     <param name="read_fast" value="$(arg read_fast)"/>
     <param name="repeat_delay" value="$(arg repeat_delay)"/>

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -57,6 +57,9 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
   std::string deviceName("Velodyne HDL-" + config_.model);
 
   private_nh.param("rpm", config_.rpm, 600.0);
+  int udp_port = 0;
+  private_nh.param("port", udp_port, static_cast<int>(UDP_PORT_NUMBER));
+  config_.udp_port = udp_port;
   ROS_INFO_STREAM(deviceName << " rotating at " << config_.rpm << " RPM");
   double frequency = (config_.rpm / 60.0);     // expected Hz rate
 
@@ -92,7 +95,8 @@ VelodyneDriver::VelodyneDriver(ros::NodeHandle node,
     }
   else
     {
-      input_.reset(new velodyne_driver::InputSocket(private_nh));
+      input_.reset(new velodyne_driver::InputSocket(private_nh,
+                                                    config_.udp_port));
     }
 
   // raw data output topic

--- a/velodyne_driver/src/driver/driver.h
+++ b/velodyne_driver/src/driver/driver.h
@@ -44,6 +44,7 @@ private:
     std::string model;               ///< device model name
     int    npackets;                 ///< number of packets to collect
     double rpm;                      ///< device rotation rate (RPMs)
+    uint16_t udp_port;               ///< velodyne broadcast port
   } config_;
 
   boost::shared_ptr<Input> input_;


### PR DESCRIPTION
This allows multiple velodynes to broadcast to the same computer, each with a corresponding node to listen on the appropriate port.