### PR TITLE
Added filter to ignore position data while reading from pcap file

### DIFF
--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -240,10 +240,22 @@ namespace velodyne_driver
             // Keep the reader from blowing through the file.
             if (read_fast_ == false)
               packet_rate_.sleep();
-            
-            memcpy(&pkt->data[0], pkt_data+42, packet_size);
-            pkt->stamp = ros::Time::now();
-            empty_ = false;
+            if((header)->len - 42 == 1206)
+            {
+				memcpy(&pkt->data[0], pkt_data+42, packet_size);
+				pkt->stamp = ros::Time::now();
+				
+			}else if((header)->len-42 == 512)
+			{
+				ROS_INFO_ONCE("Position data ignored ");
+                return 1;
+			}else
+			{
+				ROS_WARN("Incorrect data length %d (1206 LIDAR data, 512 position data): ",
+                     (header)->len-42);
+                return 1;
+			}
+			empty_ = false;
             return 0;                   // success
           }
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -142,16 +142,16 @@ namespace velodyne_driver
         ssize_t nbytes = recvfrom(sockfd_, &pkt->data[0],
                                   packet_size,  0, NULL, NULL);
 
-	if (nbytes < 0)
-	  {
+    if (nbytes < 0)
+      {
             if (errno != EWOULDBLOCK)
- 	      {
+          {
                 perror("recvfail");
-		ROS_INFO("recvfail");
+        ROS_INFO("recvfail");
                 return 1;
-	      }
-	  }
-	else if ((size_t) nbytes == packet_size)
+          }
+      }
+    else if ((size_t) nbytes == packet_size)
           {
             // read successful, done now
             break;
@@ -242,20 +242,20 @@ namespace velodyne_driver
               packet_rate_.sleep();
             if((header)->len - 42 == 1206)
             {
-				memcpy(&pkt->data[0], pkt_data+42, packet_size);
-				pkt->stamp = ros::Time::now();
-				
-			}else if((header)->len-42 == 512)
-			{
-				ROS_INFO_ONCE("Position data ignored ");
+                memcpy(&pkt->data[0], pkt_data+42, packet_size);
+                pkt->stamp = ros::Time::now();
+
+            }else if((header)->len-42 == 512)
+            {
+                ROS_INFO_ONCE("Position data ignored ");
                 return 1;
-			}else
-			{
-				ROS_WARN("Incorrect data length %d (1206 LIDAR data, 512 position data): ",
+            }else
+            {
+                ROS_WARN("Incorrect data length %d (1206 LIDAR data, 512 position data): ",
                      (header)->len-42);
                 return 1;
-			}
-			empty_ = false;
+            }
+            empty_ = false;
             return 0;                   // success
           }
 


### PR DESCRIPTION
While playing pcap file of Velodyne 32E I found gaps in the scan which down not occur when directly connecting to hardware. 
I happens so as when connecting to hardware it connects to LIDAR data port 2368 and ignores position port 8308. But while reading pcap file it reads all data packets treating position data as LIDAR data which is not parsed correctly and causes a gap in the point cloud data.

Currently just ignored those packets, later would like to publish those packet in a separate topic both from port 8308 when connected to hardware and from pcap file so that GPS data can be utilized.