### PR TITLE
Fixed azimuth overflow bug.

### DIFF
--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -316,7 +316,7 @@ namespace velodyne_rawdata
           
           /** correct for the laser rotation as a function of timing during the firings **/
           azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);
-          azimuth_corrected = (int)round(fmod(azimuth_corrected_f,36000.0));
+          azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
           
           /*condition added to avoid calculating points which are not
             in the interesting defined area (min_angle < area < max_angle)*/


### PR DESCRIPTION
Fix for VLP16 unpack:
For interpolated azimuth values between 35999.5 and 36000.0 the nested round(fmod())
yields a value of 36000 which is invalid and overflows the pre-computed sin/cos arrays,
since they only go form 0..35999
I switched the order of rounding and modulo so this doesn't happen.