### PR TITLE
[driver] add way to use PCAP time

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -104,6 +104,7 @@ namespace velodyne_driver
     bool read_fast_;
     double repeat_delay_;
     ros::Rate packet_rate_;
+    bpf_program pcap_filter_;
   };
 
 } // velodyne_driver namespace

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -88,7 +88,8 @@ namespace velodyne_driver
               std::string filename="",
               bool read_once=false,
               bool read_fast=false,
-              double repeat_delay=0.0);
+              double repeat_delay=0.0,
+              bool use_pcap_time=false);
     ~InputPCAP();
 
     virtual int getPacket(velodyne_msgs::VelodynePacket *pkt);
@@ -103,6 +104,7 @@ namespace velodyne_driver
     bool read_once_;
     bool read_fast_;
     double repeat_delay_;
+    bool use_pcap_time_;
     ros::Rate packet_rate_;
     bpf_program pcap_filter_;
   };

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -14,6 +14,7 @@
   <arg name="read_once" default="false" />
   <arg name="read_fast" default="false" />
   <arg name="repeat_delay" default="0.0" />
+  <arg name="use_pcap_time" default="false" />
   <arg name="rpm" default="600.0" />
   <arg name="frame_id" default="velodyne" />
   <node pkg="nodelet" type="nodelet" name="driver_nodelet"
@@ -23,6 +24,7 @@
     <param name="read_once" value="$(arg read_once)"/>
     <param name="read_fast" value="$(arg read_fast)"/>
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
+    <param name="use_pcap_time" value="$(arg use_pcap_time)"/>
     <param name="rpm" value="$(arg rpm)"/>
     <param name="frame_id" value="$(arg frame_id)"/>
   </node>    

--- a/velodyne_driver/mainpage.dox
+++ b/velodyne_driver/mainpage.dox
@@ -45,6 +45,7 @@ Parameters:
    possible (default false).
  - \b ~input/repeat_delay (double): number of seconds to delay before
    repeating input file (default: 0.0).
+ - \b ~input/use_pcap_time (bool): if true, use PCAP time (default false).
 
 \section vdump_command Vdump Command
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -216,6 +216,7 @@ namespace velodyne_driver
         ROS_FATAL("Error opening Velodyne socket dump file.");
         return;
       }
+    pcap_compile(pcap_, &pcap_filter_, "udp port 2368", 1, PCAP_NETMASK_UNKNOWN);
   }
 
 
@@ -237,6 +238,9 @@ namespace velodyne_driver
         int res;
         if ((res = pcap_next_ex(pcap_, &header, &pkt_data)) >= 0)
           {
+            // if packet is not laser firing data, continue
+            if (pcap_offline_filter( &pcap_filter_, header, pkt_data ) == 0)
+              continue;
             // Keep the reader from blowing through the file.
             if (read_fast_ == false)
               packet_rate_.sleep();

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -246,7 +246,7 @@ namespace velodyne_driver
               packet_rate_.sleep();
             
             memcpy(&pkt->data[0], pkt_data+42, packet_size);
-            pkt->stamp = ros::Time::now();
+            pkt->stamp = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000);
             empty_ = false;
             return 0;                   // success
           }

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -181,13 +181,15 @@ namespace velodyne_driver
    *  @param read_once read PCAP in a loop, unless false
    *  @param read_fast read PCAP at device rate, unless false
    *  @param repeat_delay time to wait before repeating PCAP data
+   *  @param use_pcap_time use PCAP time, unless false
    */
   InputPCAP::InputPCAP(ros::NodeHandle private_nh,
                        double packet_rate,
                        std::string filename,
                        bool read_once,
                        bool read_fast,
-                       double repeat_delay):
+                       double repeat_delay,
+                       bool use_pcap_time):
     Input(),
     packet_rate_(packet_rate)
   {
@@ -200,6 +202,7 @@ namespace velodyne_driver
     private_nh.param("read_once", read_once_, read_once);
     private_nh.param("read_fast", read_fast_, read_fast);
     private_nh.param("repeat_delay", repeat_delay_, repeat_delay);
+    private_nh.param("use_pcap_time", use_pcap_time_, use_pcap_time);
 
     if (read_once_)
       ROS_INFO("Read input file only once.");
@@ -246,7 +249,15 @@ namespace velodyne_driver
               packet_rate_.sleep();
             
             memcpy(&pkt->data[0], pkt_data+42, packet_size);
-            pkt->stamp = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000);
+            if (use_pcap_time_)
+              {
+                pkt->stamp = ros::Time(header->ts.tv_sec,
+                                       header->ts.tv_usec * 1000);
+              }
+            else
+              {
+                pkt->stamp = ros::Time::now();
+              }
             empty_ = false;
             return 0;                   // success
           }


### PR DESCRIPTION
Hello,

I added a parameter as requested in #57
I can remove ae96b31 if not fitted.

To be able to get the time in a rosbag, you will need to convert it using:

``` python
with rosbag.Bag(file_in) as bag_in:
    with rosbag.Bag(file_out, 'w') as bag_out:
        for _, msg, _ in bag_in.read_messages(topics=[topic]):
            bag_out.write(topic, msg, msg.header.stamp)
```

Best,
Pierrick
