### PR TITLE
Add method to organize point clouds for VLP-16

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -61,11 +61,11 @@ namespace velodyne_rawdata
   
   
   /** Special Defines for VLP16 support **/
-  static const int VLP16_FIRINGS_PER_BLOCK = 2;
-  static const int VLP16_SCANS_PER_FIRING = 16;
-  static const int VLP16_BLOCK_TDURATION = 110.592;
-  static const int VLP16_DSR_TOFFSET = 2.304;
-  static const int VLP16_FIRING_TOFFSET = 55.296;
+  static const int    VLP16_FIRINGS_PER_BLOCK =   2;
+  static const int    VLP16_SCANS_PER_FIRING  =  16;
+  static const float  VLP16_BLOCK_TDURATION   = 110.592f;   // [µs]
+  static const float  VLP16_DSR_TOFFSET       =   2.304f;   // [µs]
+  static const float  VLP16_FIRING_TOFFSET    =  55.296f;   // [µs]
   
 
   /** \brief Raw Velodyne data block.

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -142,6 +142,13 @@ namespace velodyne_rawdata
     
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);
+    
+    /** \brief Returns the scanner's number of laser beams.
+     */
+    int getNumLasers()
+    {
+      return calibration_.num_lasers;
+    }
 
   private:
 

--- a/velodyne_pointcloud/src/conversions/CMakeLists.txt
+++ b/velodyne_pointcloud/src/conversions/CMakeLists.txt
@@ -26,13 +26,13 @@ install(TARGETS ringcolors_nodelet
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-add_executable(transform_node transform_node.cc transform.cc)
+add_executable(transform_node transform_node.cc transform.cc convert.cc)
 target_link_libraries(transform_node velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS transform_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(transform_nodelet transform_nodelet.cc transform.cc)
+add_library(transform_nodelet transform_nodelet.cc transform.cc convert.cc)
 target_link_libraries(transform_nodelet velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS transform_nodelet

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -76,13 +76,13 @@ namespace velodyne_pointcloud
     organizePointCloud(outMsg, data_->getNumLasers());
 
     // publish the accumulated cloud message
-    ROS_DEBUG_STREAM("Publishing " << outMsg->height * outMsg->width
+    ROS_DEBUG_STREAM("Publishing " << outMsg->height << " x " <<  outMsg->width
                      << " Velodyne points, time: " << outMsg->header.stamp);
     output_.publish(outMsg);
   }
   
   void Convert::organizePointCloud(
-      velodyne_rawdata::VPointCloud::Ptr pc, int numLasers)
+      velodyne_rawdata::VPointCloud::Ptr& pc, int numLasers)
   {
     // Rearrange only data coming from VLP-16.
     if (numLasers != velodyne_rawdata::VLP16_SCANS_PER_FIRING)
@@ -111,14 +111,12 @@ namespace velodyne_pointcloud
       
       // Point clouds are organized from upper left to lower right.
       // Compute the row and column of the point cloud.
-      int col     = p / velodyne_rawdata::VLP16_SCANS_PER_FIRING;
-      int laserId = p % velodyne_rawdata::VLP16_SCANS_PER_FIRING;
-      int row     = (30 - 15*(laserId%2) - laserId) / 2;
+      int col = p / velodyne_rawdata::VLP16_SCANS_PER_FIRING;
+      int row = 15 - pc->at(p).ring;
       organizedPc->at(col, row) = pc->at(p);
     }
     
     pc = organizedPc;
-    ROS_INFO_STREAM("w x h = " << pc->width << " x " << pc->height);
   }
 
 } // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -91,16 +91,14 @@ namespace velodyne_pointcloud
     // Allocate the organized point cloud.
     int height = velodyne_rawdata::VLP16_SCANS_PER_FIRING;
     int width  = pc->width*pc->height / height;
-    if (pc->width*pc->height % height > 0) {
-      width++;
-    }
+    if (pc->width*pc->height % height > 0) { width++; }
     
     velodyne_rawdata::VPoint defaultPointValue;
     defaultPointValue.x         = std::numeric_limits<float>::infinity();
     defaultPointValue.y         = std::numeric_limits<float>::infinity();
     defaultPointValue.z         = std::numeric_limits<float>::infinity();
     defaultPointValue.intensity = 0.0f;
-    defaultPointValue.ring      = std::numeric_limits<uint16_t>::infinity();
+    defaultPointValue.ring      = std::numeric_limits<uint16_t>::max();
     
     velodyne_rawdata::VPointCloud::Ptr organizedPc(
           new velodyne_rawdata::VPointCloud(width, height, defaultPointValue));
@@ -112,7 +110,7 @@ namespace velodyne_pointcloud
       // Point clouds are organized from upper left to lower right.
       // Compute the row and column of the point cloud.
       int col = p / velodyne_rawdata::VLP16_SCANS_PER_FIRING;
-      int row = 15 - pc->at(p).ring;
+      int row = velodyne_rawdata::VLP16_SCANS_PER_FIRING-1 - pc->at(p).ring;
       organizedPc->at(col, row) = pc->at(p);
     }
     

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -33,19 +33,20 @@ namespace velodyne_pointcloud
 
     Convert(ros::NodeHandle node, ros::NodeHandle private_nh);
     ~Convert() {}
+    
+    /// \brief Rearranges a given 1D point cloud and makes it an organized cloud.
+    /// \param[in;out] pc point cloud that is organized.
+    /// \param[in] numLasers number of laser beams of the Velodyne lidar in use.
+    /// \todo Currently only works for VLP-16. Add support for other models.
+    static void organizePointCloud(velodyne_rawdata::VPointCloud::Ptr& pc, 
+                                   int numLasers);
 
   private:
     
     void callback(velodyne_pointcloud::VelodyneConfigConfig &config,
                 uint32_t level);
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
-    
-    /// \brief Rearranges a given 1D point cloud and makes it an organized cloud.
-    /// \param[in;out] pc point cloud that is organized.
-    /// \param[in] numLasers number of laser beams of the Velodyne lidar in use.
-    /// \todo Currently only works for VLP-16. Add support for other models.
-    void organizePointCloud(velodyne_rawdata::VPointCloud::Ptr& pc, 
-                            int numLasers);
+
 
     ///Pointer to dynamic reconfigure service srv_
     boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -39,6 +39,13 @@ namespace velodyne_pointcloud
     void callback(velodyne_pointcloud::VelodyneConfigConfig &config,
                 uint32_t level);
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
+    
+    /// \brief Rearranges a given 1D point cloud and makes it an organized cloud.
+    /// \param[in;out] pc point cloud that is organized.
+    /// \param[in] numLasers number of laser beams of the Velodyne lidar in use.
+    /// \todo Currently only works for VLP-16. Add support for other models.
+    void organizePointCloud(velodyne_rawdata::VPointCloud::Ptr pc, 
+                            int numLasers);
 
     ///Pointer to dynamic reconfigure service srv_
     boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -44,7 +44,7 @@ namespace velodyne_pointcloud
     /// \param[in;out] pc point cloud that is organized.
     /// \param[in] numLasers number of laser beams of the Velodyne lidar in use.
     /// \todo Currently only works for VLP-16. Add support for other models.
-    void organizePointCloud(velodyne_rawdata::VPointCloud::Ptr pc, 
+    void organizePointCloud(velodyne_rawdata::VPointCloud::Ptr& pc, 
                             int numLasers);
 
     ///Pointer to dynamic reconfigure service srv_

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -158,6 +158,8 @@ namespace velodyne_rawdata
              ||(config_.min_angle > config_.max_angle 
              && (raw->blocks[i].rotation <= config_.max_angle 
              || raw->blocks[i].rotation >= config_.min_angle))){
+          
+          // convert polar coordinates to Euclidean XYZ
           float distance = tmp.uint * DISTANCE_RESOLUTION;
           distance += corrections.dist_correction;
   
@@ -258,7 +260,7 @@ namespace velodyne_rawdata
   
           if (pointInRange(distance)) {
   
-            // convert polar coordinates to Euclidean XYZ
+            // append this point to the cloud
             VPoint point;
             point.ring = corrections.laser_ring;
             point.x = x_coord;
@@ -266,7 +268,6 @@ namespace velodyne_rawdata
             point.z = z_coord;
             point.intensity = (uint8_t) intensity;
   
-            // append this point to the cloud
             pc.points.push_back(point);
             ++pc.width;
           }
@@ -435,19 +436,27 @@ namespace velodyne_rawdata
             intensity = (intensity < min_intensity) ? min_intensity : intensity;
             intensity = (intensity > max_intensity) ? max_intensity : intensity;
     
+            // append this point to the cloud
+            VPoint point;
+            point.ring = corrections.laser_ring;
             if (pointInRange(distance)) {
-    
-              // append this point to the cloud
-              VPoint point;
-              point.ring = corrections.laser_ring;
+
               point.x = x_coord;
               point.y = y_coord;
               point.z = z_coord;
               point.intensity = (uint8_t) intensity;
-
-              pc.points.push_back(point);
-              ++pc.width;
             }
+            else {
+              
+              // If not in the specified range, set point to NaN.
+              point.x = std::numeric_limits<float>::infinity();
+              point.y = std::numeric_limits<float>::infinity();
+              point.z = std::numeric_limits<float>::infinity();
+              point.intensity = 0u;
+            }
+
+            pc.points.push_back(point);
+            ++pc.width;
           }
         }
       }


### PR DESCRIPTION
Add a method that organizes a 1D point cloud read from VLP-16. As @spuetz pointed out, this may accelerate post-processing steps. 

I tried to alter as little code as possible.

I tested the code using multiple VLP-16. Other model's data streams will still be processed as 1D clouds
