### PR TITLE
Support for VLP-16's dual-return mode

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -166,7 +166,21 @@ namespace velodyne_rawdata
     float cos_rot_table_[ROTATION_MAX_UNITS];
     
     /** add private function to handle the VLP16 **/ 
+    /** @brief convert raw VLP16 packet to point cloud
+     *
+     *  @param pkt raw packet to unpack
+     *  @param pc shared pointer to point cloud (points are appended)
+     */
     void unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+    
+    /// \brief Read one VLP-16 firing sequence (half a block).
+    /// \param[in] data pointer to first range-intensity data element.
+    /// \param[in] azimuth azimuth angle of first data element.
+    /// \param[in] azimuth_diff azimuth difference to first element of next firing.
+    /// \param[out] pc point cloud to which the read points are appended.
+    void read_firing_vlp16(const uint8_t* data, 
+                           float azimuth, float azimuth_diff,
+                           VPointCloud &pc);
 
     /** in-line test whether a point is in range */
     bool pointInRange(float range)

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -66,6 +66,11 @@ namespace velodyne_rawdata
     Dual      = 0x39
   };
   
+  enum SensorModel {
+    Hdl32e  = 0x21,
+    Vlp16   = 0x22
+  };
+  
   /** Special Defines for VLP16 support **/
   static const int    VLP16_FIRINGS_PER_BLOCK =   2;
   static const int    VLP16_SCANS_PER_FIRING  =  16;
@@ -149,7 +154,15 @@ namespace velodyne_rawdata
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);
     
-    ReturnMode getReturnMode(const velodyne_msgs::VelodynePacket& pkt);
+    /// \brief Returns the mode of operation of the laser scanner.
+    /// \note For this feature to work, the sensor must run at least firmware
+    ///   version 3.0.23.0.
+    static ReturnMode getReturnMode(const velodyne_msgs::VelodynePacket& pkt);
+    
+    /// \brief Returns the sensor model.
+    /// \note For this feature to work, the sensor must run at least firmware
+    ///   version 3.0.23.0.
+    static SensorModel getSensorModel(const velodyne_msgs::VelodynePacket& pkt);
 
   private:
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -66,11 +66,48 @@ namespace velodyne_rawdata
     Dual      = 0x39
   };
   
+  inline std::ostream& operator<<(std::ostream& os, ReturnMode mode)
+  {
+    switch (mode)
+    {
+    case Strongest:
+      os << "strongest"; 
+      break;
+    case Last:
+      os << "last"; 
+      break;
+    case Dual:
+      os << "dual";
+      break;
+    default:
+      os << "[unknown return mode]";
+    }
+    
+    return os;
+  }
+  
   enum SensorModel {
     Hdl32e  = 0x21,
     Vlp16   = 0x22
   };
   
+  inline std::ostream& operator<<(std::ostream& os, SensorModel model)
+  {
+    switch (model)
+    {
+    case Hdl32e:
+      os << "HDL-32E";
+      break;
+    case Vlp16:
+      os << "VLP-16";
+      break;
+    default:
+      os << "[unknown sensor model]";
+    }
+    
+    return os;
+  }
+   
   /** Special Defines for VLP16 support **/
   static const int    VLP16_FIRINGS_PER_BLOCK =   2;
   static const int    VLP16_SCANS_PER_FIRING  =  16;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -148,6 +148,8 @@ namespace velodyne_rawdata
     
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);
+    
+    ReturnMode getReturnMode(const velodyne_msgs::VelodynePacket& pkt);
 
   private:
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -55,10 +55,16 @@ namespace velodyne_rawdata
   static const float DISTANCE_RESOLUTION = 0.002f; /**< meters */
   static const float DISTANCE_MAX_UNITS = (DISTANCE_MAX
                                            / DISTANCE_RESOLUTION + 1.0);
+  
   /** @todo make this work for both big and little-endian machines */
   static const uint16_t UPPER_BANK = 0xeeff;
   static const uint16_t LOWER_BANK = 0xddff;
   
+  enum ReturnMode {
+    Strongest = 0x37,
+    Last      = 0x38,
+    Dual      = 0x39
+  };
   
   /** Special Defines for VLP16 support **/
   static const int    VLP16_FIRINGS_PER_BLOCK =   2;

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -80,8 +80,9 @@ namespace velodyne_pointcloud
 
     // Only for VLP-16 in dual-return mode: process two messages at once 
     // to capture a full scanner revolution.
-    if (getSensorModel(scanMsg->packets[0])   == Vlp16
-        && getReturnMode(scanMsg->packets[0]) == Dual) {
+    SensorModel model = getSensorModel(scanMsg->packets[0]);
+    ReturnMode  mode  = getReturnMode(scanMsg->packets[0]);
+    if (model == Vlp16 && mode == Dual) {
       if (bufferedMsg_) {
         // Insert the buffered message into the current one.
         outMsg->insert(outMsg->begin(), bufferedMsg_->begin(), bufferedMsg_->end());
@@ -94,8 +95,10 @@ namespace velodyne_pointcloud
     }
 
     // publish the accumulated cloud message
-    ROS_DEBUG_STREAM("Publishing " << outMsg->height * outMsg->width
-                     << " Velodyne points, time: " << outMsg->header.stamp);
+    ROS_DEBUG_STREAM("Publishing " << outMsg->height * outMsg->width << "points "
+                     << "from " << model << " "
+                     << "in " << mode << " return mode, "
+                     << "time: " << outMsg->header.stamp);
     output_.publish(outMsg);
   }
 

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -95,7 +95,7 @@ namespace velodyne_pointcloud
     }
 
     // publish the accumulated cloud message
-    ROS_DEBUG_STREAM("Publishing " << outMsg->height * outMsg->width << "points "
+    ROS_DEBUG_STREAM("Publishing " << outMsg->height << " x " << outMsg->width << "points "
                      << "from " << model << " "
                      << "in " << mode << " return mode, "
                      << "time: " << outMsg->header.stamp);

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -47,6 +47,7 @@ namespace velodyne_pointcloud
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     ros::Subscriber velodyne_scan_;
     ros::Publisher output_;
+    velodyne_rawdata::VPointCloud::Ptr bufferedMsg_;
 
     /// configuration parameters
     typedef struct {

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -47,11 +47,6 @@ namespace velodyne_pointcloud
     tf_filter_->registerCallback(boost::bind(&Transform::processScan, this, _1));
   }
 
-  /** @brief Callback for raw scan messages.
-   *
-   *  @pre TF message filter has already waited until the transform to
-   *       the configured @c frame_id can succeed.
-   */
   void
     Transform::processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg)
   {

--- a/velodyne_pointcloud/src/conversions/transform.h
+++ b/velodyne_pointcloud/src/conversions/transform.h
@@ -51,6 +51,11 @@ namespace velodyne_pointcloud
 
   private:
 
+    /** @brief Callback for raw scan messages.
+     *
+     *  @pre TF message filter has already waited until the transform to
+     *       the configured @c frame_id can succeed.
+     */
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
 
     boost::shared_ptr<velodyne_rawdata::RawData> data_;

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -275,23 +275,20 @@ namespace velodyne_rawdata
     }
   }
   
-  /** @brief convert raw VLP16 packet to point cloud
-   *
-   *  @param pkt raw packet to unpack
-   *  @param pc shared pointer to point cloud (points are appended)
-   */
   void RawData::unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt,
                              VPointCloud &pc)
   {
     float azimuth;
     float azimuth_diff;
     float last_azimuth_diff;
-    float azimuth_corrected_f;
-    int azimuth_corrected;
-    float x, y, z;
-    float intensity;
 
     const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
+
+    // Read scanner's return mode from factory bytes:
+    // 0x37 ... strongest return
+    // 0x38 ... last return
+    // 0x39 ... dual return
+    uint8_t return_mode = raw->status[PACKET_STATUS_SIZE-2];
 
     for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
 
@@ -315,140 +312,147 @@ namespace velodyne_rawdata
       }
 
       for (int firing=0, k=0; firing < VLP16_FIRINGS_PER_BLOCK; firing++){
-        for (int dsr=0; dsr < VLP16_SCANS_PER_FIRING; dsr++, k+=RAW_SCAN_SIZE){
-          velodyne_pointcloud::LaserCorrection &corrections = 
-            calibration_.laser_corrections[dsr];
-
-          /** Position Calculation */
-          union two_bytes tmp;
-          tmp.bytes[0] = raw->blocks[block].data[k];
-          tmp.bytes[1] = raw->blocks[block].data[k+1];
-          
-          /** correct for the laser rotation as a function of timing during the firings **/
-          azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);
-          azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
-          
-          /*condition added to avoid calculating points which are not
-            in the interesting defined area (min_angle < area < max_angle)*/
-          if ((azimuth_corrected >= config_.min_angle 
-               && azimuth_corrected <= config_.max_angle 
-               && config_.min_angle < config_.max_angle)
-               ||(config_.min_angle > config_.max_angle 
-               && (azimuth_corrected <= config_.max_angle 
-               || azimuth_corrected >= config_.min_angle))){
-
-            // convert polar coordinates to Euclidean XYZ
-            float distance = tmp.uint * DISTANCE_RESOLUTION;
-            distance += corrections.dist_correction;
-            
-            float cos_vert_angle = corrections.cos_vert_correction;
-            float sin_vert_angle = corrections.sin_vert_correction;
-            float cos_rot_correction = corrections.cos_rot_correction;
-            float sin_rot_correction = corrections.sin_rot_correction;
-    
-            // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
-            // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-            float cos_rot_angle = 
-              cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
-              sin_rot_table_[azimuth_corrected] * sin_rot_correction;
-            float sin_rot_angle = 
-              sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
-              cos_rot_table_[azimuth_corrected] * sin_rot_correction;
-    
-            float horiz_offset = corrections.horiz_offset_correction;
-            float vert_offset = corrections.vert_offset_correction;
-    
-            // Compute the distance in the xy plane (w/o accounting for rotation)
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            float xy_distance = distance * cos_vert_angle + vert_offset * sin_vert_angle;
-    
-            // Calculate temporal X, use absolute value.
-            float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-            // Calculate temporal Y, use absolute value
-            float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-            if (xx < 0) xx=-xx;
-            if (yy < 0) yy=-yy;
-      
-            // Get 2points calibration values,Linear interpolation to get distance
-            // correction for X and Y, that means distance correction use
-            // different value at different distance
-            float distance_corr_x = 0;
-            float distance_corr_y = 0;
-            if (corrections.two_pt_correction_available) {
-              distance_corr_x = 
-                (corrections.dist_correction - corrections.dist_correction_x)
-                  * (xx - 2.4) / (25.04 - 2.4) 
-                + corrections.dist_correction_x;
-              distance_corr_x -= corrections.dist_correction;
-              distance_corr_y = 
-                (corrections.dist_correction - corrections.dist_correction_y)
-                  * (yy - 1.93) / (25.04 - 1.93)
-                + corrections.dist_correction_y;
-              distance_corr_y -= corrections.dist_correction;
-            }
-    
-            float distance_x = distance + distance_corr_x;
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            xy_distance = distance_x * cos_vert_angle + vert_offset * sin_vert_angle ;
-            x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-    
-            float distance_y = distance + distance_corr_y;
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            xy_distance = distance_y * cos_vert_angle + vert_offset * sin_vert_angle ;
-            y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-    
-            // Using distance_y is not symmetric, but the velodyne manual
-            // does this.
-            /**the new term of 'vert_offset * cos_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
+        read_firing_vlp16(raw->blocks[block].data, azimuth, azimuth_diff, pc);
+      }
+    }
+  }
   
-    
-            /** Use standard ROS coordinate system (right-hand rule) */
-            float x_coord = y;
-            float y_coord = -x;
-            float z_coord = z;
-    
-            /** Intensity Calculation */
-            float min_intensity = corrections.min_intensity;
-            float max_intensity = corrections.max_intensity;
-    
-            intensity = raw->blocks[block].data[k+2];
-    
-            float focal_offset = 256 
-                               * (1 - corrections.focal_distance / 13100) 
-                               * (1 - corrections.focal_distance / 13100);
-            float focal_slope = corrections.focal_slope;
-            intensity += focal_slope * (abs(focal_offset - 256 * 
-              (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
-            intensity = (intensity < min_intensity) ? min_intensity : intensity;
-            intensity = (intensity > max_intensity) ? max_intensity : intensity;
-    
-            if (pointInRange(distance)) {
-    
-              // append this point to the cloud
-              VPoint point;
-              point.ring = corrections.laser_ring;
-              point.x = x_coord;
-              point.y = y_coord;
-              point.z = z_coord;
-              point.intensity = (uint8_t) intensity;
+  void RawData::read_firing_vlp16(const uint8_t* data, 
+                                  float azimuth, float azimuth_diff,
+                                  VPointCloud &pc)
+  {
+    int k = 0;int firing=0;
+    for (int dsr=0; dsr < VLP16_SCANS_PER_FIRING; dsr++, k+=RAW_SCAN_SIZE){
+      velodyne_pointcloud::LaserCorrection &corrections = 
+        calibration_.laser_corrections[dsr];
 
-              pc.points.push_back(point);
-              ++pc.width;
-            }
-          }
+      /** Position Calculation */
+      union two_bytes tmp;
+      tmp.bytes[0] = data[k];
+      tmp.bytes[1] = data[k+1];
+      
+      /** correct for the laser rotation as a function of timing during the firings **/
+      float azimuth_corrected_f = azimuth + (dsr*VLP16_DSR_TOFFSET) * (azimuth_diff/VLP16_FIRING_TOFFSET);
+      int azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
+      
+      /*condition added to avoid calculating points which are not
+        in the interesting defined area (min_angle < area < max_angle)*/
+      if ((azimuth_corrected >= config_.min_angle 
+           && azimuth_corrected <= config_.max_angle 
+           && config_.min_angle < config_.max_angle)
+           ||(config_.min_angle > config_.max_angle 
+           && (azimuth_corrected <= config_.max_angle 
+           || azimuth_corrected >= config_.min_angle))){
+
+        // convert polar coordinates to Euclidean XYZ
+        float distance = tmp.uint * DISTANCE_RESOLUTION;
+        distance += corrections.dist_correction;
+        
+        float cos_vert_angle = corrections.cos_vert_correction;
+        float sin_vert_angle = corrections.sin_vert_correction;
+        float cos_rot_correction = corrections.cos_rot_correction;
+        float sin_rot_correction = corrections.sin_rot_correction;
+
+        // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
+        // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
+        float cos_rot_angle = 
+          cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
+          sin_rot_table_[azimuth_corrected] * sin_rot_correction;
+        float sin_rot_angle = 
+          sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
+          cos_rot_table_[azimuth_corrected] * sin_rot_correction;
+
+        float horiz_offset = corrections.horiz_offset_correction;
+        float vert_offset = corrections.vert_offset_correction;
+
+        // Compute the distance in the xy plane (w/o accounting for rotation)
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        float xy_distance = distance * cos_vert_angle + vert_offset * sin_vert_angle;
+
+        // Calculate temporal X, use absolute value.
+        float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+        // Calculate temporal Y, use absolute value
+        float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+        if (xx < 0) xx=-xx;
+        if (yy < 0) yy=-yy;
+  
+        // Get 2points calibration values,Linear interpolation to get distance
+        // correction for X and Y, that means distance correction use
+        // different value at different distance
+        float distance_corr_x = 0;
+        float distance_corr_y = 0;
+        if (corrections.two_pt_correction_available) {
+          distance_corr_x = 
+            (corrections.dist_correction - corrections.dist_correction_x)
+              * (xx - 2.4) / (25.04 - 2.4) 
+            + corrections.dist_correction_x;
+          distance_corr_x -= corrections.dist_correction;
+          distance_corr_y = 
+            (corrections.dist_correction - corrections.dist_correction_y)
+              * (yy - 1.93) / (25.04 - 1.93)
+            + corrections.dist_correction_y;
+          distance_corr_y -= corrections.dist_correction;
+        }
+
+        float distance_x = distance + distance_corr_x;
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        xy_distance = distance_x * cos_vert_angle + vert_offset * sin_vert_angle ;
+        float x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+
+        float distance_y = distance + distance_corr_y;
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        xy_distance = distance_y * cos_vert_angle + vert_offset * sin_vert_angle ;
+        float y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+
+        // Using distance_y is not symmetric, but the velodyne manual
+        // does this.
+        /**the new term of 'vert_offset * cos_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        float z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
+
+        /** Use standard ROS coordinate system (right-hand rule) */
+        float x_coord = y;
+        float y_coord = -x;
+        float z_coord = z;
+
+        /** Intensity Calculation */
+        float min_intensity = corrections.min_intensity;
+        float max_intensity = corrections.max_intensity;
+
+        float intensity = data[k+2];
+
+        float focal_offset = 256 
+                           * (1 - corrections.focal_distance / 13100) 
+                           * (1 - corrections.focal_distance / 13100);
+        float focal_slope = corrections.focal_slope;
+        intensity += focal_slope * (abs(focal_offset - 256 * 
+          (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
+        intensity = (intensity < min_intensity) ? min_intensity : intensity;
+        intensity = (intensity > max_intensity) ? max_intensity : intensity;
+
+        if (pointInRange(distance)) {
+
+          // append this point to the cloud
+          VPoint point;
+          point.ring = corrections.laser_ring;
+          point.x = x_coord;
+          point.y = y_coord;
+          point.z = z_coord;
+          point.intensity = (uint8_t) intensity;
+
+          pc.points.push_back(point);
+          ++pc.width;
         }
       }
     }

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -284,11 +284,8 @@ namespace velodyne_rawdata
 
     const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
 
-    // Read scanner's return mode from factory bytes:
-    // 0x37 ... strongest return
-    // 0x38 ... last return
-    // 0x39 ... dual return
-    uint8_t return_mode = raw->status[PACKET_STATUS_SIZE-2];
+    // Read scanner's return mode from factory bytes.
+    ReturnMode return_mode = (ReturnMode)raw->status[PACKET_STATUS_SIZE-2];
 
     // Process the packet's blocks.
     for (int block = 0; block < BLOCKS_PER_PACKET; block++) {

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -275,6 +275,14 @@ namespace velodyne_rawdata
     }
   }
   
+  ReturnMode RawData::getReturnMode(const velodyne_msgs::VelodynePacket& pkt)
+  {
+    const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
+    
+    // Read scanner's return mode from factory bytes.
+    return (ReturnMode)raw->status[PACKET_STATUS_SIZE-2];    
+  }
+  
   void RawData::unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt,
                              VPointCloud &pc)
   {
@@ -283,9 +291,6 @@ namespace velodyne_rawdata
     float last_azimuth_diff;
 
     const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
-
-    // Read scanner's return mode from factory bytes.
-    ReturnMode return_mode = (ReturnMode)raw->status[PACKET_STATUS_SIZE-2];
 
     // Process the packet's blocks.
     for (int block = 0; block < BLOCKS_PER_PACKET; block++) {

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -106,11 +106,6 @@ namespace velodyne_rawdata
    return 0;
   }
 
-  /** @brief convert raw packet to point cloud
-   *
-   *  @param pkt raw packet to unpack
-   *  @param pc shared pointer to point cloud (points are appended)
-   */
   void RawData::unpack(const velodyne_msgs::VelodynePacket &pkt,
                        VPointCloud &pc)
   {
@@ -275,32 +270,18 @@ namespace velodyne_rawdata
     }
   }
   
-  ReturnMode RawData::getReturnMode(const velodyne_msgs::VelodynePacket& pkt)
-  {
-    const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
-    
-    // Read scanner's return mode from factory bytes.
-    return (ReturnMode)raw->status[PACKET_STATUS_SIZE-2];    
-  }
-  
-  SensorModel RawData::getSensorModel(const velodyne_msgs::VelodynePacket& pkt)
-  {
-    const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
-   
-    // Read the scanner model from factory bytes.
-    return (SensorModel)raw->status[PACKET_STATUS_SIZE-1];
-  }
-  
-  void RawData::unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt,
-                             VPointCloud &pc)
+  void RawData::unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc)
   {
     float azimuth;
     float azimuth_diff;
     float last_azimuth_diff;
+    float azimuth_corrected_f;
+    int azimuth_corrected;
+    float x, y, z;
+    float intensity;
 
     const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
-
-    // Process the packet's blocks.
+    
     for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
 
       // ignore packets with mangled or otherwise different contents
@@ -313,157 +294,153 @@ namespace velodyne_rawdata
         return;                         // bad packet: skip the rest
       }
 
-      // Calculate difference between current and next block's azimuth angle.
+      // Calculate the index step to the next block with new azimuth value.
+      int i_diff = (getReturnMode(pkt) == Dual) ? 2 : 1;
+        
+      // Calculate difference between current and next block's azimuth angle.       
       azimuth = (float)(raw->blocks[block].rotation);
-      if (block < (BLOCKS_PER_PACKET-1)){
-        azimuth_diff = (float)((36000 + raw->blocks[block+1].rotation - raw->blocks[block].rotation)%36000);
+      if (block < (BLOCKS_PER_PACKET-i_diff)){
+        azimuth_diff = (float)((36000 + raw->blocks[block+i_diff].rotation - raw->blocks[block].rotation)%36000);
         last_azimuth_diff = azimuth_diff;
       }else{
         azimuth_diff = last_azimuth_diff;
       }
 
-      for (int firing=0; firing < VLP16_FIRINGS_PER_BLOCK; firing++){
-        read_firing_vlp16(raw->blocks[block].data + firing*VLP16_SCANS_PER_FIRING*RAW_SCAN_SIZE, 
-                          azimuth, azimuth_diff, pc);
-      }
-    }
-  }
-  
-  void RawData::read_firing_vlp16(const uint8_t* data, 
-                                  float azimuth, float azimuth_diff,
-                                  VPointCloud &pc)
-  {
-    for (int dsr=0; dsr < VLP16_SCANS_PER_FIRING; dsr++){
-      velodyne_pointcloud::LaserCorrection &corrections = 
-        calibration_.laser_corrections[dsr];
+      for (int firing=0, k=0; firing < VLP16_FIRINGS_PER_BLOCK; firing++){
+        for (int dsr=0; dsr < VLP16_SCANS_PER_FIRING; dsr++, k+=RAW_SCAN_SIZE){
+          velodyne_pointcloud::LaserCorrection &corrections = 
+            calibration_.laser_corrections[dsr];
 
-      /** Position Calculation */
-      union two_bytes tmp;
-      tmp.bytes[0] = data[dsr*RAW_SCAN_SIZE];
-      tmp.bytes[1] = data[dsr*RAW_SCAN_SIZE + 1];
+          /** Position Calculation */
+          union two_bytes tmp;
+          tmp.bytes[0] = raw->blocks[block].data[k];
+          tmp.bytes[1] = raw->blocks[block].data[k+1];
+          
+          /** correct for the laser rotation as a function of timing during the firings **/
+          azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);
+          azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
+          
+          /*condition added to avoid calculating points which are not
+            in the interesting defined area (min_angle < area < max_angle)*/
+          if ((azimuth_corrected >= config_.min_angle 
+               && azimuth_corrected <= config_.max_angle 
+               && config_.min_angle < config_.max_angle)
+               ||(config_.min_angle > config_.max_angle 
+               && (azimuth_corrected <= config_.max_angle 
+               || azimuth_corrected >= config_.min_angle))){
+
+            // convert polar coordinates to Euclidean XYZ
+            float distance = tmp.uint * DISTANCE_RESOLUTION;
+            distance += corrections.dist_correction;
+            
+            float cos_vert_angle = corrections.cos_vert_correction;
+            float sin_vert_angle = corrections.sin_vert_correction;
+            float cos_rot_correction = corrections.cos_rot_correction;
+            float sin_rot_correction = corrections.sin_rot_correction;
+    
+            // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
+            // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
+            float cos_rot_angle = 
+              cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
+              sin_rot_table_[azimuth_corrected] * sin_rot_correction;
+            float sin_rot_angle = 
+              sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
+              cos_rot_table_[azimuth_corrected] * sin_rot_correction;
+    
+            float horiz_offset = corrections.horiz_offset_correction;
+            float vert_offset = corrections.vert_offset_correction;
+    
+            // Compute the distance in the xy plane (w/o accounting for rotation)
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            float xy_distance = distance * cos_vert_angle + vert_offset * sin_vert_angle;
+    
+            // Calculate temporal X, use absolute value.
+            float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+            // Calculate temporal Y, use absolute value
+            float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+            if (xx < 0) xx=-xx;
+            if (yy < 0) yy=-yy;
       
-      /** correct for the laser rotation as a function of timing during the firings **/
-      float azimuth_corrected_f = azimuth + (dsr*VLP16_DSR_TOFFSET) * (azimuth_diff/VLP16_FIRING_TOFFSET);
-      int azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
-      
-      /*condition added to avoid calculating points which are not
-        in the interesting defined area (min_angle < area < max_angle)*/
-      if ((azimuth_corrected >= config_.min_angle 
-           && azimuth_corrected <= config_.max_angle 
-           && config_.min_angle < config_.max_angle)
-           ||(config_.min_angle > config_.max_angle 
-           && (azimuth_corrected <= config_.max_angle 
-           || azimuth_corrected >= config_.min_angle))){
-
-        // convert polar coordinates to Euclidean XYZ
-        float distance = tmp.uint * DISTANCE_RESOLUTION;
-        distance += corrections.dist_correction;
-        
-        float cos_vert_angle = corrections.cos_vert_correction;
-        float sin_vert_angle = corrections.sin_vert_correction;
-        float cos_rot_correction = corrections.cos_rot_correction;
-        float sin_rot_correction = corrections.sin_rot_correction;
-
-        // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
-        // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-        float cos_rot_angle = 
-          cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
-          sin_rot_table_[azimuth_corrected] * sin_rot_correction;
-        float sin_rot_angle = 
-          sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
-          cos_rot_table_[azimuth_corrected] * sin_rot_correction;
-
-        float horiz_offset = corrections.horiz_offset_correction;
-        float vert_offset = corrections.vert_offset_correction;
-
-        // Compute the distance in the xy plane (w/o accounting for rotation)
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        float xy_distance = distance * cos_vert_angle + vert_offset * sin_vert_angle;
-
-        // Calculate temporal X, use absolute value.
-        float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-        // Calculate temporal Y, use absolute value
-        float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-        if (xx < 0) xx=-xx;
-        if (yy < 0) yy=-yy;
+            // Get 2points calibration values,Linear interpolation to get distance
+            // correction for X and Y, that means distance correction use
+            // different value at different distance
+            float distance_corr_x = 0;
+            float distance_corr_y = 0;
+            if (corrections.two_pt_correction_available) {
+              distance_corr_x = 
+                (corrections.dist_correction - corrections.dist_correction_x)
+                  * (xx - 2.4) / (25.04 - 2.4) 
+                + corrections.dist_correction_x;
+              distance_corr_x -= corrections.dist_correction;
+              distance_corr_y = 
+                (corrections.dist_correction - corrections.dist_correction_y)
+                  * (yy - 1.93) / (25.04 - 1.93)
+                + corrections.dist_correction_y;
+              distance_corr_y -= corrections.dist_correction;
+            }
+    
+            float distance_x = distance + distance_corr_x;
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            xy_distance = distance_x * cos_vert_angle + vert_offset * sin_vert_angle ;
+            x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+    
+            float distance_y = distance + distance_corr_y;
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            xy_distance = distance_y * cos_vert_angle + vert_offset * sin_vert_angle ;
+            y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+    
+            // Using distance_y is not symmetric, but the velodyne manual
+            // does this.
+            /**the new term of 'vert_offset * cos_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
   
-        // Get 2points calibration values,Linear interpolation to get distance
-        // correction for X and Y, that means distance correction use
-        // different value at different distance
-        float distance_corr_x = 0;
-        float distance_corr_y = 0;
-        if (corrections.two_pt_correction_available) {
-          distance_corr_x = 
-            (corrections.dist_correction - corrections.dist_correction_x)
-              * (xx - 2.4) / (25.04 - 2.4) 
-            + corrections.dist_correction_x;
-          distance_corr_x -= corrections.dist_correction;
-          distance_corr_y = 
-            (corrections.dist_correction - corrections.dist_correction_y)
-              * (yy - 1.93) / (25.04 - 1.93)
-            + corrections.dist_correction_y;
-          distance_corr_y -= corrections.dist_correction;
-        }
+    
+            /** Use standard ROS coordinate system (right-hand rule) */
+            float x_coord = y;
+            float y_coord = -x;
+            float z_coord = z;
+    
+            /** Intensity Calculation */
+            float min_intensity = corrections.min_intensity;
+            float max_intensity = corrections.max_intensity;
+    
+            intensity = raw->blocks[block].data[k+2];
+    
+            float focal_offset = 256 
+                               * (1 - corrections.focal_distance / 13100) 
+                               * (1 - corrections.focal_distance / 13100);
+            float focal_slope = corrections.focal_slope;
+            intensity += focal_slope * (abs(focal_offset - 256 * 
+              (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
+            intensity = (intensity < min_intensity) ? min_intensity : intensity;
+            intensity = (intensity > max_intensity) ? max_intensity : intensity;
+    
+            if (pointInRange(distance)) {
+    
+              // append this point to the cloud
+              VPoint point;
+              point.ring = corrections.laser_ring;
+              point.x = x_coord;
+              point.y = y_coord;
+              point.z = z_coord;
+              point.intensity = (uint8_t) intensity;
 
-        float distance_x = distance + distance_corr_x;
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        xy_distance = distance_x * cos_vert_angle + vert_offset * sin_vert_angle ;
-        float x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-
-        float distance_y = distance + distance_corr_y;
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        xy_distance = distance_y * cos_vert_angle + vert_offset * sin_vert_angle ;
-        float y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-
-        // Using distance_y is not symmetric, but the velodyne manual
-        // does this.
-        /**the new term of 'vert_offset * cos_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        float z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
-
-        /** Use standard ROS coordinate system (right-hand rule) */
-        float x_coord = y;
-        float y_coord = -x;
-        float z_coord = z;
-
-        /** Intensity Calculation */
-        float min_intensity = corrections.min_intensity;
-        float max_intensity = corrections.max_intensity;
-
-        float intensity = data[dsr*RAW_SCAN_SIZE + 2];
-
-        float focal_offset = 256 
-                           * (1 - corrections.focal_distance / 13100) 
-                           * (1 - corrections.focal_distance / 13100);
-        float focal_slope = corrections.focal_slope;
-        intensity += focal_slope * (abs(focal_offset - 256 * 
-          (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
-        intensity = (intensity < min_intensity) ? min_intensity : intensity;
-        intensity = (intensity > max_intensity) ? max_intensity : intensity;
-
-        if (pointInRange(distance)) {
-
-          // append this point to the cloud
-          VPoint point;
-          point.ring = corrections.laser_ring;
-          point.x = x_coord;
-          point.y = y_coord;
-          point.z = z_coord;
-          point.intensity = (uint8_t) intensity;
-
-          pc.points.push_back(point);
-          ++pc.width;
+              pc.points.push_back(point);
+              ++pc.width;
+            }
+          }
         }
       }
     }

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -283,6 +283,14 @@ namespace velodyne_rawdata
     return (ReturnMode)raw->status[PACKET_STATUS_SIZE-2];    
   }
   
+  SensorModel RawData::getSensorModel(const velodyne_msgs::VelodynePacket& pkt)
+  {
+    const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
+   
+    // Read the scanner model from factory bytes.
+    return (SensorModel)raw->status[PACKET_STATUS_SIZE-1];
+  }
+  
   void RawData::unpack_vlp16(const velodyne_msgs::VelodynePacket &pkt,
                              VPointCloud &pc)
   {


### PR DESCRIPTION
Added a few changes to automatically adapt the way point clouds are calculated to the current return mode of the VLP-16: strongest, last, or dual.

The dual-return mode, which is not yet supported in the current version of velodyne_pointcloud, is of great use not only in forestry applications; if offers more data when looking through transparent objects in standard mapping applications.

In detail, the following functionality is added:
1. Read the factory bytes in the Velodyne packet to detect in which return mode the sensor is running.
2. Adapt the azimuth calculation according to the return mode.
3. In dual return mode, output one point cloud for two received packets. In this way, every scan represents a full scanner revolution.
