### PR TITLE
Fix output of calibration data onto console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
 *.tar.gz
 *~
+*.user
 TAGS

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -90,7 +90,7 @@ namespace velodyne_pointcloud
         // transform the packet point cloud into the target frame
         try
           {
-            ROS_DEBUG_STREAM("transforming from" << inPc_.header.frame_id
+            ROS_DEBUG_STREAM("transforming from " << inPc_.header.frame_id
                              << " to " << config_.frame_id);
             pcl_ros::transformPointCloud(config_.frame_id, inPc_, tfPc_,
                                          listener_);

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -145,8 +145,8 @@ namespace velodyne_pointcloud
         // store this ring number with its corresponding laser number
         calibration.laser_corrections[next_index].laser_ring = ring;
         next_angle = min_seen;
-        ROS_INFO_STREAM("laser_ring[" << next_index << "] = " << ring
-                         << ", angle = " << next_angle);
+        ROS_INFO("laser_ring[%2u] = %2u, angle = %+.6f", 
+                 next_index, ring, next_angle);
       }
     }
   }

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -95,7 +95,7 @@ namespace velodyne_rawdata
       return -1;
     }
     
-    ROS_INFO_STREAM("Data will be processed as a VLP-16...num_lasers: " << calibration_.num_lasers);
+    ROS_INFO_STREAM("Number of lasers: " << calibration_.num_lasers << ".");
     
     // Set up cached values for sin and cos of all the possible headings
     for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index) {


### PR DESCRIPTION
Previously, the console log always told you that velodyne_pointcloud interprets data as VLP-16 data, no matter what the calibration file. When you load a HDL-64E calibration file, for example, you get the following output on the console:
```
...
[ INFO] [1455797371.476088236]: laser_ring[2] = 58, angle = 0.00969335
[ INFO] [1455797371.476152253]: laser_ring[3] = 59, angle = 0.0152117
[ INFO] [1455797371.476215947]: laser_ring[24] = 60, angle = 0.0211378
[ INFO] [1455797371.476280336]: laser_ring[25] = 61, angle = 0.0280837
[ INFO] [1455797371.476343884]: laser_ring[28] = 62, angle = 0.032985
[ INFO] [1455797371.476407944]: laser_ring[29] = 63, angle = 0.0387013
[ INFO] [1455797371.477147818]: Data will be processed as a VLP-16...num_lasers: 64
```
Obviously, the data will not `be processed as a VLP-16`. So I fixed the message and aligned the output of the calibration data:
```
...
[ INFO] [1455793606.065383820]: laser_ring[ 2] = 58, angle = +0.009693
[ INFO] [1455793606.065416682]: laser_ring[ 3] = 59, angle = +0.015212
[ INFO] [1455793606.065449289]: laser_ring[24] = 60, angle = +0.021138
[ INFO] [1455793606.065481949]: laser_ring[25] = 61, angle = +0.028084
[ INFO] [1455793606.065514419]: laser_ring[28] = 62, angle = +0.032985
[ INFO] [1455793606.065546940]: laser_ring[29] = 63, angle = +0.038701
[ INFO] [1455793606.066163127]: Number of lasers: 64.
```