### PR TITLE
Dynamic reconfiguration of transform_node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.tar.gz
 *~
 *.user
+doc
 TAGS

--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -10,7 +10,9 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     sensor_msgs
     tf
     velodyne_driver
-    velodyne_msgs)
+    velodyne_msgs
+    dynamic_reconfigure
+)
 
 find_package(catkin REQUIRED COMPONENTS
              ${${PROJECT_NAME}_CATKIN_DEPS} pcl_conversions)
@@ -28,13 +30,16 @@ find_library(YAML_CPP_LIBRARY
              PATHS ${YAML_CPP_LIBRARY_DIRS})
              
 generate_dynamic_reconfigure_options(
-  cfg/VelodyneConfig.cfg)
+  cfg/CloudNode.cfg cfg/TransformNode.cfg
+)
 
 if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
 add_definitions(-DHAVE_NEW_YAMLCPP)
 endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} 
+  ${dynamic_reconfigure_PACKAGE_PATH}/cmake/cfgbuild.cmake
+)
 
 catkin_package(
     CATKIN_DEPENDS ${${PROJECT_NAME}_CATKIN_DEPS}

--- a/velodyne_pointcloud/cfg/CloudNode.cfg
+++ b/velodyne_pointcloud/cfg/CloudNode.cfg
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+PACKAGE = "velodyne_pointcloud"
+
+from math import pi
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("min_range", double_t, 0, "min range to publish", 0.9, 0.1, 10.0)
+gen.add("max_range", double_t, 0, "max range to publish", 130, 0.1, 200)
+gen.add("view_direction", double_t, 0, "angle defining the center of view",
+        0.0, -pi, pi)
+gen.add("view_width", double_t, 0, "angle defining the view width",
+        2*pi, 0.0, 2*pi)
+
+exit(gen.generate(PACKAGE, "cloud_node", "CloudNode"))

--- a/velodyne_pointcloud/cfg/TransformNode.cfg
+++ b/velodyne_pointcloud/cfg/TransformNode.cfg
@@ -12,5 +12,6 @@ gen.add("view_direction", double_t, 0, "angle defining the center of view",
         0.0, -pi, pi)
 gen.add("view_width", double_t, 0, "angle defining the view width",
         2*pi, 0.0, 2*pi)
+gen.add("frame_id", str_t, 0, "new frame of reference for point clouds", "odom")
 
-exit(gen.generate(PACKAGE, "velodyne_pointcloud", "VelodyneConfig"))
+exit(gen.generate(PACKAGE, "transform_node", "TransformNode"))

--- a/velodyne_pointcloud/cfg/TransformNode.cfg
+++ b/velodyne_pointcloud/cfg/TransformNode.cfg
@@ -2,16 +2,38 @@
 PACKAGE = "velodyne_pointcloud"
 
 from math import pi
-from dynamic_reconfigure.parameter_generator_catkin import *
+import dynamic_reconfigure.parameter_generator_catkin as pgc
 
-gen = ParameterGenerator()
+gen = pgc.ParameterGenerator()
 
-gen.add("min_range", double_t, 0, "min range to publish", 0.9, 0.1, 10.0)
-gen.add("max_range", double_t, 0, "max range to publish", 130, 0.1, 200)
-gen.add("view_direction", double_t, 0, "angle defining the center of view",
-        0.0, -pi, pi)
-gen.add("view_width", double_t, 0, "angle defining the view width",
-        2*pi, 0.0, 2*pi)
-gen.add("frame_id", str_t, 0, "new frame of reference for point clouds", "odom")
+gen.add("min_range", 
+  pgc.double_t, 
+  0, 
+  "min range to publish", 
+  0.9, 0.1, 10.0)
+  
+gen.add("max_range", 
+  pgc.double_t, 
+  0, 
+  "max range to publish", 
+  130, 0.1, 200)
+  
+gen.add("view_direction", 
+  pgc.double_t, 
+  0, 
+  "angle defining the center of view",
+  0.0, -pi, pi)
+  
+gen.add("view_width", 
+  pgc.double_t, 
+  0, 
+  "angle defining the view width",
+  2*pi, 0.0, 2*pi)
+  
+gen.add("frame_id", 
+  pgc.str_t, 
+  0, 
+  "new frame of reference for point clouds", 
+  "odom")
 
 exit(gen.generate(PACKAGE, "transform_node", "TransformNode"))

--- a/velodyne_pointcloud/src/conversions/CMakeLists.txt
+++ b/velodyne_pointcloud/src/conversions/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_executable(cloud_node cloud_node.cc convert.cc)
+add_dependencies(cloud_node ${PROJECT_NAME}_gencfg)
 target_link_libraries(cloud_node velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS cloud_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 add_library(cloud_nodelet cloud_nodelet.cc convert.cc)
+add_dependencies(cloud_nodelet ${PROJECT_NAME}_gencfg)
 target_link_libraries(cloud_nodelet velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS cloud_nodelet
@@ -27,12 +29,14 @@ install(TARGETS ringcolors_nodelet
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 add_executable(transform_node transform_node.cc transform.cc)
+add_dependencies(transform_node ${PROJECT_NAME}_gencfg)
 target_link_libraries(transform_node velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS transform_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 add_library(transform_nodelet transform_nodelet.cc transform.cc)
+add_dependencies(transform_nodelet ${PROJECT_NAME}_gencfg)
 target_link_libraries(transform_nodelet velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS transform_nodelet

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -31,8 +31,8 @@ namespace velodyne_pointcloud
       node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
       
     srv_ = boost::make_shared <dynamic_reconfigure::Server<velodyne_pointcloud::
-      VelodyneConfigConfig> > (private_nh);
-    dynamic_reconfigure::Server<velodyne_pointcloud::VelodyneConfigConfig>::
+      CloudNodeConfig> > (private_nh);
+    dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig>::
       CallbackType f;
     f = boost::bind (&Convert::callback, this, _1, _2);
     srv_->setCallback (f);
@@ -44,7 +44,7 @@ namespace velodyne_pointcloud
                      ros::TransportHints().tcpNoDelay(true));
   }
   
-  void Convert::callback(velodyne_pointcloud::VelodyneConfigConfig &config,
+  void Convert::callback(velodyne_pointcloud::CloudNodeConfig &config,
                 uint32_t level)
   {
   ROS_INFO("Reconfigure Request");

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -23,7 +23,7 @@
 #include <velodyne_pointcloud/rawdata.h>
 
 #include <dynamic_reconfigure/server.h>
-#include <velodyne_pointcloud/VelodyneConfigConfig.h>
+#include <velodyne_pointcloud/CloudNodeConfig.h>
 
 namespace velodyne_pointcloud
 {
@@ -36,13 +36,13 @@ namespace velodyne_pointcloud
 
   private:
     
-    void callback(velodyne_pointcloud::VelodyneConfigConfig &config,
+    void callback(velodyne_pointcloud::CloudNodeConfig &config,
                 uint32_t level);
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
 
     ///Pointer to dynamic reconfigure service srv_
     boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::
-      VelodyneConfigConfig> > srv_;
+      CloudNodeConfig> > srv_;
     
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     ros::Subscriber velodyne_scan_;

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -25,13 +25,10 @@ namespace velodyne_pointcloud
 {
   /** @brief Constructor. */
   Transform::Transform(ros::NodeHandle node, ros::NodeHandle private_nh):
-    data_(new velodyne_rawdata::RawData())
+    data_(new velodyne_rawdata::RawData()),
+    tf_prefix_(tf::getPrefixParam(private_nh))
   {
-    private_nh.param("frame_id", config_.frame_id, std::string("odom"));
-    std::string tf_prefix = tf::getPrefixParam(private_nh);
-    config_.frame_id = tf::resolve(tf_prefix, config_.frame_id);
-    ROS_INFO_STREAM("target frame ID: " << config_.frame_id);
-
+    // Read calibration.
     data_->setup(private_nh);
 
     // advertise output point cloud (before subscribing to input data)
@@ -42,7 +39,7 @@ namespace velodyne_pointcloud
       TransformNodeConfig> > (private_nh);
     dynamic_reconfigure::Server<velodyne_pointcloud::TransformNodeConfig>::
       CallbackType f;
-    f = boost::bind (&Transform::callback, this, _1, _2);
+    f = boost::bind (&Transform::reconfigure_callback, this, _1, _2);
     srv_->setCallback (f);
     
     // subscribe to VelodyneScan packets using transform filter
@@ -54,13 +51,14 @@ namespace velodyne_pointcloud
     tf_filter_->registerCallback(boost::bind(&Transform::processScan, this, _1));
   }
   
-  void Transform::callback(velodyne_pointcloud::TransformNodeConfig &config,
-                uint32_t level)
+  void Transform::reconfigure_callback(
+      velodyne_pointcloud::TransformNodeConfig &config, uint32_t level)
   {
-    ROS_INFO("Reconfigure Request");
+    ROS_INFO_STREAM("Reconfigure request.");
     data_->setParameters(config.min_range, config.max_range, 
                          config.view_direction, config.view_width);
-    config_.frame_id = config.frame_id;
+    config_.frame_id = tf::resolve(tf_prefix_, config.frame_id);
+    ROS_INFO_STREAM("Target frame ID: " << config_.frame_id);
   }
 
   /** @brief Callback for raw scan messages.

--- a/velodyne_pointcloud/src/conversions/transform.h
+++ b/velodyne_pointcloud/src/conversions/transform.h
@@ -59,9 +59,10 @@ namespace velodyne_pointcloud
     ///Pointer to dynamic reconfigure service srv_
     boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::
       TransformNodeConfig> > srv_;
-    void callback(velodyne_pointcloud::TransformNodeConfig &config,
+    void reconfigure_callback(velodyne_pointcloud::TransformNodeConfig &config,
                   uint32_t level);
     
+    const std::string tf_prefix_;
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     message_filters::Subscriber<velodyne_msgs::VelodyneScan> velodyne_scan_;
     tf::MessageFilter<velodyne_msgs::VelodyneScan> *tf_filter_;

--- a/velodyne_pointcloud/src/conversions/transform.h
+++ b/velodyne_pointcloud/src/conversions/transform.h
@@ -26,6 +26,9 @@
 #include <velodyne_pointcloud/rawdata.h>
 #include <velodyne_pointcloud/point_types.h>
 
+#include <dynamic_reconfigure/server.h>
+#include <velodyne_pointcloud/TransformNodeConfig.h>
+
 // include template implementations to transform a custom point cloud
 #include <pcl_ros/impl/transforms.hpp>
 
@@ -53,6 +56,12 @@ namespace velodyne_pointcloud
 
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
 
+    ///Pointer to dynamic reconfigure service srv_
+    boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::
+      TransformNodeConfig> > srv_;
+    void callback(velodyne_pointcloud::TransformNodeConfig &config,
+                  uint32_t level);
+    
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     message_filters::Subscriber<velodyne_msgs::VelodyneScan> velodyne_scan_;
     tf::MessageFilter<velodyne_msgs::VelodyneScan> *tf_filter_;


### PR DESCRIPTION
### Before
Until now, transform_node does neither read parameters other than frame_id from the command line nor does it expose these parameters via dynamic reconfigure. As parameters like max_range and view_width are initialized to zero, transform_node always returns an empty point cloud:
`rosrun velodyne_pointcloud transform_node _calibration:=ros/calibration/velodyne_64e.yaml`
![screenshot from 2016-02-22 10 39 24](https://cloud.githubusercontent.com/assets/16705093/13214629/1cd667fc-d951-11e5-873b-3f22cd9f4718.png)

### After
The commits in this pull request alter transform_node's behavior: Now, the node launches an reconfigure server just as cloud_node. The default configuration values are the same as in cloud_node. In addition to cloud_node, transform node exposes the frame_id parameter to reconfiguration. Now, the output looks like this:
`rosrun velodyne_pointcloud transform_node _calibration:=ros/calibration/velodyne_64e.yaml`
![screenshot from 2016-02-22 10 41 40](https://cloud.githubusercontent.com/assets/16705093/13214648/41cb6d78-d951-11e5-85f3-a470985eedec.png)
