### PR TITLE
allow floats in min/max_intensity and make horiz_offset_correction optional

### DIFF
--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -73,11 +73,17 @@ namespace velodyne_pointcloud
     node[DIST_CORRECTION_X] >> correction.second.dist_correction_x;
     node[DIST_CORRECTION_Y] >> correction.second.dist_correction_y;
     node[VERT_OFFSET_CORRECTION] >> correction.second.vert_offset_correction;
-    node[HORIZ_OFFSET_CORRECTION] >> correction.second.horiz_offset_correction;
 #ifdef HAVE_NEW_YAMLCPP
+    if (node[HORIZ_OFFSET_CORRECTION])
+      node[HORIZ_OFFSET_CORRECTION] >>
+        correction.second.horiz_offset_correction;
 #else
+    if (const YAML::Node *pName = node.FindValue(HORIZ_OFFSET_CORRECTION))
+      *pName >> correction.second.horiz_offset_correction;
 #endif
     else
+      correction.second.horiz_offset_correction = 0;
+
     const YAML::Node * max_intensity_node;
 #ifdef HAVE_NEW_YAMLCPP
     max_intensity_node = node[MAX_INTENSITY];

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -75,23 +75,48 @@ namespace velodyne_pointcloud
     node[VERT_OFFSET_CORRECTION] >> correction.second.vert_offset_correction;
     node[HORIZ_OFFSET_CORRECTION] >> correction.second.horiz_offset_correction;
 #ifdef HAVE_NEW_YAMLCPP
-    if (node[MAX_INTENSITY])
-      node[MAX_INTENSITY] >> correction.second.max_intensity;
 #else
-    if (const YAML::Node *pName = node.FindValue(MAX_INTENSITY))
-      *pName >> correction.second.max_intensity;
 #endif
     else
-      correction.second.max_intensity = 255;
+    const YAML::Node * max_intensity_node;
 #ifdef HAVE_NEW_YAMLCPP
-    if (node[MIN_INTENSITY])
-      node[MIN_INTENSITY] >> correction.second.min_intensity;
+    max_intensity_node = node[MAX_INTENSITY];
 #else
-    if (const YAML::Node *pName = node.FindValue(MIN_INTENSITY))
-      *pName >> correction.second.min_intensity;
+    max_intensity_node = node.FindValue(MAX_INTENSITY);
 #endif
-    else
+    if (max_intensity_node) {
+      try {
+        *max_intensity_node >> correction.second.max_intensity;
+      } catch(const YAML::InvalidScalar & exc) {
+        float max_intensity_float;
+        *max_intensity_node >> max_intensity_float;
+        correction.second.max_intensity = floor(max_intensity_float);
+        ROS_WARN_ONCE("Implicitly converting 'max_intensity' values from floats to ints.");
+      }
+    }
+    else {
+      correction.second.max_intensity = 255;
+    }
+
+    const YAML::Node * min_intensity_node;
+#ifdef HAVE_NEW_YAMLCPP
+    min_intensity_node = node[MIN_INTENSITY];
+#else
+    min_intensity_node = node.FindValue(MIN_INTENSITY);
+#endif
+    if (min_intensity_node) {
+      try {
+        *min_intensity_node >> correction.second.min_intensity;
+      } catch(const YAML::InvalidScalar & exc) {
+        float min_intensity_float;
+        *min_intensity_node >> min_intensity_float;
+        correction.second.min_intensity = floor(min_intensity_float);
+        ROS_WARN_ONCE("Implicitly converting 'min_intensity' values from floats to ints.");
+      }
+    }
+    else {
       correction.second.min_intensity = 0;
+    }
     node[FOCAL_DISTANCE] >> correction.second.focal_distance;
     node[FOCAL_SLOPE] >> correction.second.focal_slope;
 


### PR DESCRIPTION
I had need to import a file which contained floats instead of ints for the `min_intensity` and `max_intensity` fields in a calibration file. So the first thing this pr does is change how those values are extracted from YAML. First it tries to get them as ints, but if that throws an InvalidScalar exception, then I try to put it in a float and if that works I cast the floor the float to the int storage and warn once.

I believe this will also address https://github.com/ros-drivers/velodyne/issues/45. It will attempt to extract `horiz_offset_correction` from the YAML file and if it is not there, then it defaults to `0`, which I believe is the consensus that was reached in #45.