### PR TITLE
Add dynamic latency configuration

### DIFF
--- a/velodyne_pointcloud/cfg/CloudNode.cfg
+++ b/velodyne_pointcloud/cfg/CloudNode.cfg
@@ -12,5 +12,7 @@ gen.add("view_direction", double_t, 0, "angle defining the center of view",
         0.0, -pi, pi)
 gen.add("view_width", double_t, 0, "angle defining the view width",
         2*pi, 0.0, 2*pi)
+gen.add("latency", double_t,  0, "constant latency of the sensor in seconds",
+        0.0, -1.0, 1.0)
 
 exit(gen.generate(PACKAGE, "cloud_node", "CloudNode"))

--- a/velodyne_pointcloud/cfg/TransformNode.cfg
+++ b/velodyne_pointcloud/cfg/TransformNode.cfg
@@ -35,5 +35,12 @@ gen.add("frame_id",
   0, 
   "new frame of reference for point clouds", 
   "odom")
+  
+gen.add("latency",
+  pgc.double_t,
+  0,
+  "constant latency of the sensor in seconds",
+  0.0, -1.0, 1.0)
+  
 
 exit(gen.generate(PACKAGE, "transform_node", "TransformNode"))

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -35,7 +35,7 @@ namespace velodyne_pointcloud
     dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig>::
       CallbackType f;
     f = boost::bind (&Convert::callback, this, _1, _2);
-    srv_->setCallback (f);
+    srv_->setCallback (f); // Set callback function und call initially
 
     // subscribe to VelodyneScan packets
     velodyne_scan_ =
@@ -50,6 +50,7 @@ namespace velodyne_pointcloud
   ROS_INFO("Reconfigure Request");
   data_->setParameters(config.min_range, config.max_range, config.view_direction,
                        config.view_width);
+  config_.latency = config.latency;
   }
 
   /** @brief Callback for raw scan messages. */
@@ -62,7 +63,7 @@ namespace velodyne_pointcloud
     velodyne_rawdata::VPointCloud::Ptr
       outMsg(new velodyne_rawdata::VPointCloud());
     // outMsg's header is a pcl::PCLHeader, convert it before stamp assignment
-    outMsg->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+    outMsg->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp - config_.latency * 1000000ull;
     outMsg->header.frame_id = scanMsg->header.frame_id;
     outMsg->height = 1;
 

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -50,6 +50,7 @@ namespace velodyne_pointcloud
 
     /// configuration parameters
     typedef struct {
+      double latency;                  ///< Constant latency of the sensor in seconds. Is subtracted from the time stamp.
       int npackets;                    ///< number of packets to combine
     } Config;
     Config config_;

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -25,8 +25,8 @@ namespace velodyne_pointcloud
 {
   /** @brief Constructor. */
   Transform::Transform(ros::NodeHandle node, ros::NodeHandle private_nh):
-    data_(new velodyne_rawdata::RawData()),
-    tf_prefix_(tf::getPrefixParam(private_nh))
+    tf_prefix_(tf::getPrefixParam(private_nh)),
+    data_(new velodyne_rawdata::RawData())
   {
     // Read calibration.
     data_->setup(private_nh);

--- a/velodyne_pointcloud/src/conversions/transform.h
+++ b/velodyne_pointcloud/src/conversions/transform.h
@@ -72,6 +72,7 @@ namespace velodyne_pointcloud
     /// configuration parameters
     typedef struct {
       std::string frame_id;          ///< target frame ID
+      double latency;                ///< Constant latency of the sensor in seconds. Is subtracted from the time stamp.
     } Config;
     Config config_;
 


### PR DESCRIPTION
This pull request enables both the transform_node and the cloud_node to manipulate the capture time of sensor data via dynamic_reconfigure. This allows the user to compensate constant time offsets. The feature is highly valuable for the synchronization of multi-sensor setups. The chosen latency time (parameter: '~latency') is subtracted from the time stamps, so that this parameter should typically be positive. For my setup, `~latency` is in the range of 20ms.