### PR TITLE
update velodyne_driver package description to include all models

### DIFF
--- a/velodyne_driver/package.xml
+++ b/velodyne_driver/package.xml
@@ -3,7 +3,7 @@
   <name>velodyne_driver</name>
   <version>1.2.0</version>
   <description>
-    ROS device driver for Velodyne HDL-64E, and HDL-32 LIDARs.
+    ROS device driver for Velodyne 3D LIDARs.
   </description>
   <maintainer email="jack.oquin@gmail.com">Jack O'Quin</maintainer>
   <maintainer email="brice.rebsamen@gmail.com">Brice Rebsamen</maintainer>


### PR DESCRIPTION
The driver currently supports all Velodyne LiDAR models.