### PR TITLE
GCC Build Warnings

### DIFF
--- a/velodyne_pointcloud/src/conversions/colors.cc
+++ b/velodyne_pointcloud/src/conversions/colors.cc
@@ -81,7 +81,7 @@ namespace velodyne_pointcloud
 
         // color lasers with the rainbow array
         int color = inMsg->points[i].ring % N_COLORS;
-        p.rgb = *reinterpret_cast<float*>(&rainbow[color]);
+        p.rgb = *reinterpret_cast<float*>(rainbow+color);
 
         outMsg->points.push_back(p);
         ++outMsg->width;

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -285,7 +285,7 @@ namespace velodyne_rawdata
   {
     float azimuth;
     float azimuth_diff;
-    float last_azimuth_diff;
+    float last_azimuth_diff=0;
     float azimuth_corrected_f;
     int azimuth_corrected;
     float x, y, z;


### PR DESCRIPTION
Building the velodyne drivers from source with strict compiler warnings/errors showed two warnings.  While none of the issues pointed out by GCC are a problem, this pull request has changes to address the warnings to silence the warning messages.  

There are two warnings being addressed:

velodyne/velodyne_pointcloud/src/lib/rawdata.cc:328:57: error: ‘last_azimuth_diff’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
           azimuth_corrected_f = azimuth + (azimuth_diff * ((dsr*VLP16_DSR_TOFFSET) + (firing*VLP16_FIRING_TOFFSET)) / VLP16_BLOCK_TDURATION);
 

velodyne/velodyne_pointcloud/src/conversions/colors.cc:84:58: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         p.rgb = *reinterpret_cast<float*>(&rainbow[color]);
                                                          ^
