### PR TITLE
New parameter “udp_timeout_ms_” introduced & 'perror' messagees converted to ROS_ERROR

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -85,6 +85,7 @@ namespace velodyne_driver
   private:
     int sockfd_;
     in_addr devip_;
+    int udp_timeout_ms_;
   };
 
 

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -16,6 +16,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="frame_id" default="velodyne" />
+  <arg name="udp_timeout_ms" default="1000" />
   <node pkg="nodelet" type="nodelet" name="driver_nodelet"
         args="load velodyne_driver/DriverNodelet velodyne_nodelet_manager" >
     <param name="model" value="$(arg model)"/>
@@ -25,6 +26,7 @@
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
     <param name="rpm" value="$(arg rpm)"/>
     <param name="frame_id" value="$(arg frame_id)"/>
+    <param name="udp_timeout_ms" value="$(arg udp_timeout_ms)"/>
   </node>    
 
 </launch>

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -73,6 +73,11 @@ namespace velodyne_driver
 
     // connect to Velodyne UDP port
     ROS_INFO_STREAM("Opening UDP socket: port " << port);
+    
+    // get parameters using private node handle
+    private_nh.param("udp_timeout_ms", udp_timeout_ms_,1000);
+    ROS_INFO_STREAM("UDP socket timeout: " << udp_timeout_ms_ << " (ms)");
+    
     sockfd_ = socket(PF_INET, SOCK_DGRAM, 0);
     if (sockfd_ == -1)
       {
@@ -115,7 +120,7 @@ namespace velodyne_driver
     struct pollfd fds[1];
     fds[0].fd = sockfd_;
     fds[0].events = POLLIN;
-    static const int POLL_TIMEOUT = 1000; // one second (in msec)
+    //static const int POLL_TIMEOUT = 1000; // one second (in msec)
 
     sockaddr_in sender_address;
     socklen_t sender_address_len = sizeof(sender_address);
@@ -142,7 +147,7 @@ namespace velodyne_driver
         // poll() until input available
         do
           {
-            int retval = poll(fds, 1, POLL_TIMEOUT);
+            int retval = poll(fds, 1, udp_timeout_ms_);
             if (retval < 0)             // poll() error?
               {
                 if (errno != EINTR)

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -81,10 +81,12 @@ namespace velodyne_driver
     sockfd_ = socket(PF_INET, SOCK_DGRAM, 0);
     if (sockfd_ == -1)
       {
-        perror("socket");               // TODO: ROS_ERROR errno
+        //perror("socket");               // TODO: ROS_ERROR errno
+        ROS_ERROR("InputSocket: Error opening socket (%s)", strerror(errno));
         return;
       }
-  
+    ROS_DEBUG("socket created ");
+    
     sockaddr_in my_addr;                     // my address information
     memset(&my_addr, 0, sizeof(my_addr));    // initialize to zeros
     my_addr.sin_family = AF_INET;            // host byte order
@@ -93,16 +95,20 @@ namespace velodyne_driver
   
     if (bind(sockfd_, (sockaddr *)&my_addr, sizeof(sockaddr)) == -1)
       {
-        perror("bind");                 // TODO: ROS_ERROR errno
+        //perror("bind");                 // TODO: ROS_ERROR errno
+        ROS_ERROR("InputSocket: Error binding socket (%s)", strerror(errno));
         return;
       }
-  
+    ROS_DEBUG("socket binded ");
+    
     if (fcntl(sockfd_,F_SETFL, O_NONBLOCK|FASYNC) < 0)
       {
-        perror("non-block");
+        //perror("non-block");
+        ROS_ERROR("InputSocket: Error setting non-block (%s)", strerror(errno));
         return;
       }
-
+    ROS_DEBUG("socket non-block set ");
+    
     ROS_DEBUG("Velodyne socket fd is %d\n", sockfd_);
   }
 
@@ -179,8 +185,9 @@ namespace velodyne_driver
           {
             if (errno != EWOULDBLOCK)
               {
-                perror("recvfail");
-                ROS_INFO("recvfail");
+                //perror("recvfail");
+                //ROS_INFO("recvfail");
+                ROS_ERROR("recvfail: %s", strerror(errno));
                 return 1;
               }
           }


### PR DESCRIPTION
Change 1:
input.h: New parameter “udp_timeout_ms_” introduced
input.cc: New parameter “udp_timeout_ms_” used to represent UDP socket timeout instead of “POLL_TIMEOUT”.
nodelet_manager.launch: The launch file updated with the same parameter “udp_timeout_ms_”

Change 2:
convert 'perror' messages to ROS_ERROR(errno) error messages
