### PR TITLE
Add more options in launch files.

### DIFF
--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -9,27 +9,27 @@
   <!-- start nodelet manager and load driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="velodyne_nodelet_manager"
         args="manager" />
+  <arg name="device_ip" default="" />
+  <arg name="frame_id" default="velodyne" />
   <arg name="model" default="64E" />
   <arg name="pcap" default="" />
-  <arg name="read_once" default="false" />
+  <arg name="port" default="2368" />
   <arg name="read_fast" default="false" />
+  <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
-  <arg name="frame_id" default="velodyne" />
-  <arg name="device_ip" default="" />
-  <arg name="port" default="2368" />
 
   <node pkg="nodelet" type="nodelet" name="driver_nodelet"
         args="load velodyne_driver/DriverNodelet velodyne_nodelet_manager" >
+    <param name="device_ip" value="$(arg device_ip)" />
+    <param name="frame_id" value="$(arg frame_id)"/>
     <param name="model" value="$(arg model)"/>
     <param name="pcap" value="$(arg pcap)"/>
-    <param name="read_once" value="$(arg read_once)"/>
+    <param name="port" value="$(arg port)" />
     <param name="read_fast" value="$(arg read_fast)"/>
+    <param name="read_once" value="$(arg read_once)"/>
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
     <param name="rpm" value="$(arg rpm)"/>
-    <param name="frame_id" value="$(arg frame_id)"/>
-    <param name="device_ip" value="$(arg device_ip)" />
-    <param name="port" value="$(arg port)" />
   </node>    
 
 </launch>

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -16,6 +16,9 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="frame_id" default="velodyne" />
+  <arg name="device_ip" default="" />
+  <arg name="port" default="2368" />
+
   <node pkg="nodelet" type="nodelet" name="driver_nodelet"
         args="load velodyne_driver/DriverNodelet velodyne_nodelet_manager" >
     <param name="model" value="$(arg model)"/>
@@ -25,6 +28,8 @@
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
     <param name="rpm" value="$(arg rpm)"/>
     <param name="frame_id" value="$(arg frame_id)"/>
+    <param name="device_ip" value="$(arg device_ip)" />
+    <param name="port" value="$(arg port)" />
   </node>    
 
 </launch>

--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -11,35 +11,35 @@
 
   <!-- declare arguments with default values -->
   <arg name="calibration" default="$(find velodyne_pointcloud)/params/32db.yaml"/>
-  <arg name="min_range" default="0.4" />
+  <arg name="device_ip" default="" />
+  <arg name="frame_id" default="velodyne" />
   <arg name="max_range" default="130.0" />
+  <arg name="min_range" default="0.4" />
   <arg name="pcap" default="" />
-  <arg name="read_once" default="false" />
+  <arg name="port" default="2368" />
   <arg name="read_fast" default="false" />
+  <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
-  <arg name="frame_id" default="velodyne" />
-  <arg name="device_ip" default="" />
-  <arg name="port" default="2368" />
 
   <!-- start nodelet manager and driver nodelets -->
   <include file="$(find velodyne_driver)/launch/nodelet_manager.launch">
+    <arg name="device_ip" value="$(arg device_ip)"/>
+    <arg name="frame_id" value="$(arg frame_id)"/>
     <arg name="model" value="32E"/>
     <arg name="pcap" value="$(arg pcap)"/>
-    <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="port" value="$(arg port)"/>
     <arg name="read_fast" value="$(arg read_fast)"/>
+    <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
-    <arg name="frame_id" value="$(arg frame_id)"/>
-    <arg name="device_ip" value="$(arg device_ip)"/>
-    <arg name="port" value="$(arg port)"/>
   </include>
 
   <!-- start cloud nodelet -->
   <include file="$(find velodyne_pointcloud)/launch/cloud_nodelet.launch">
     <arg name="calibration" value="$(arg calibration)"/>
-    <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="min_range" value="$(arg min_range)"/>
   </include>
 
 </launch>

--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -10,18 +10,36 @@
 <launch>
 
   <!-- declare arguments with default values -->
-  <arg name="pcap" default="" />
   <arg name="calibration" default="$(find velodyne_pointcloud)/params/32db.yaml"/>
+  <arg name="min_range" default="0.4" />
+  <arg name="max_range" default="130.0" />
+  <arg name="pcap" default="" />
+  <arg name="read_once" default="false" />
+  <arg name="read_fast" default="false" />
+  <arg name="repeat_delay" default="0.0" />
+  <arg name="rpm" default="600.0" />
+  <arg name="frame_id" default="velodyne" />
+  <arg name="device_ip" default="" />
+  <arg name="port" default="2368" />
 
   <!-- start nodelet manager and driver nodelets -->
   <include file="$(find velodyne_driver)/launch/nodelet_manager.launch">
     <arg name="model" value="32E"/>
     <arg name="pcap" value="$(arg pcap)"/>
+    <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="read_fast" value="$(arg read_fast)"/>
+    <arg name="repeat_delay" value="$(arg repeat_delay)"/>
+    <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="frame_id" value="$(arg frame_id)"/>
+    <arg name="device_ip" value="$(arg device_ip)"/>
+    <arg name="port" value="$(arg port)"/>
   </include>
 
   <!-- start cloud nodelet -->
   <include file="$(find velodyne_pointcloud)/launch/cloud_nodelet.launch">
     <arg name="calibration" value="$(arg calibration)"/>
+    <arg name="min_range" value="$(arg min_range)"/>
+    <arg name="max_range" value="$(arg max_range)"/>
   </include>
 
 </launch>

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -9,35 +9,35 @@
 
   <!-- declare arguments with default values -->
   <arg name="calibration" default="$(find velodyne_pointcloud)/params/VLP16db.yaml"/>
-  <arg name="min_range" default="0.4" />
+  <arg name="device_ip" default="" />
+  <arg name="frame_id" default="velodyne" />
   <arg name="max_range" default="130.0" />
+  <arg name="min_range" default="0.4" />
   <arg name="pcap" default="" />
-  <arg name="read_once" default="false" />
+  <arg name="port" default="2368" />
   <arg name="read_fast" default="false" />
+  <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
-  <arg name="frame_id" default="velodyne" />
-  <arg name="device_ip" default="" />
-  <arg name="port" default="2368" />
 
   <!-- start nodelet manager and driver nodelets -->
   <include file="$(find velodyne_driver)/launch/nodelet_manager.launch">
+    <arg name="device_ip" value="$(arg device_ip)"/>
+    <arg name="frame_id" value="$(arg frame_id)"/>
     <arg name="model" value="VLP16"/>
     <arg name="pcap" value="$(arg pcap)"/>
-    <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="port" value="$(arg port)"/>
     <arg name="read_fast" value="$(arg read_fast)"/>
+    <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
-    <arg name="frame_id" value="$(arg frame_id)"/>
-    <arg name="device_ip" value="$(arg device_ip)"/>
-    <arg name="port" value="$(arg port)"/>
   </include>
 
   <!-- start cloud nodelet -->
   <include file="$(find velodyne_pointcloud)/launch/cloud_nodelet.launch">
     <arg name="calibration" value="$(arg calibration)"/>
-    <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="min_range" value="$(arg min_range)"/>
   </include>
 
 </launch>

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -8,15 +8,29 @@
 <launch>
 
   <!-- declare arguments with default values -->
-  <arg name="pcap" default="" />
   <arg name="calibration" default="$(find velodyne_pointcloud)/params/VLP16db.yaml"/>
   <arg name="min_range" default="0.4" />
   <arg name="max_range" default="130.0" />
+  <arg name="pcap" default="" />
+  <arg name="read_once" default="false" />
+  <arg name="read_fast" default="false" />
+  <arg name="repeat_delay" default="0.0" />
+  <arg name="rpm" default="600.0" />
+  <arg name="frame_id" default="velodyne" />
+  <arg name="device_ip" default="" />
+  <arg name="port" default="2368" />
 
   <!-- start nodelet manager and driver nodelets -->
   <include file="$(find velodyne_driver)/launch/nodelet_manager.launch">
     <arg name="model" value="VLP16"/>
     <arg name="pcap" value="$(arg pcap)"/>
+    <arg name="read_once" value="$(arg read_once)"/>
+    <arg name="read_fast" value="$(arg read_fast)"/>
+    <arg name="repeat_delay" value="$(arg repeat_delay)"/>
+    <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="frame_id" value="$(arg frame_id)"/>
+    <arg name="device_ip" value="$(arg device_ip)"/>
+    <arg name="port" value="$(arg port)"/>
   </include>
 
   <!-- start cloud nodelet -->

--- a/velodyne_pointcloud/launch/cloud_nodelet.launch
+++ b/velodyne_pointcloud/launch/cloud_nodelet.launch
@@ -8,12 +8,13 @@
 
 <launch>
   <arg name="calibration" default="" />
-  <arg name="min_range" default="0.9" />
   <arg name="max_range" default="130.0" />
+  <arg name="min_range" default="0.9" />
+
   <node pkg="nodelet" type="nodelet" name="cloud_nodelet"
         args="load velodyne_pointcloud/CloudNodelet velodyne_nodelet_manager">
     <param name="calibration" value="$(arg calibration)"/>
-    <param name="min_range" value="$(arg min_range)"/>
     <param name="max_range" value="$(arg max_range)"/>
+    <param name="min_range" value="$(arg min_range)"/>
   </node>
 </launch>

--- a/velodyne_pointcloud/launch/transform_nodelet.launch
+++ b/velodyne_pointcloud/launch/transform_nodelet.launch
@@ -8,14 +8,14 @@
 
 <launch>
   <arg name="calibration" default="" />
-  <arg name="min_range" default="0.9" />
-  <arg name="max_range" default="130.0" />
   <arg name="frame_id" default="odom" />
+  <arg name="max_range" default="130.0" />
+  <arg name="min_range" default="0.9" />
   <node pkg="nodelet" type="nodelet" name="transform_nodelet"
         args="load velodyne_pointcloud/TransformNodelet velodyne_nodelet_manager" >
     <param name="calibration" value="$(arg calibration)"/>
-    <param name="min_range" value="$(arg min_range)"/>
-    <param name="max_range" value="$(arg max_range)"/>
     <param name="frame_id" value="$(arg frame_id)"/>
+    <param name="max_range" value="$(arg max_range)"/>
+    <param name="min_range" value="$(arg min_range)"/>
   </node>
 </launch>


### PR DESCRIPTION
Relative to #90 

Add the following options to VLP16 and hdl32 launch files:
- rpm, device_ip, port, read_once, read_fast, repeat_delay

In the 32e_points, there was also no min_range and max_range, I put the same as the vlp16 (though I'm not certain it's correct, 0.4 to 130), and pcap.

Finally, I added the port and device_ip to the nodelet manager.

I am not very familiar with ROS, so am not sure overriding defaults parameters with the same defaults is the best way for some of them, but couldn't find any other way. Please correct me if I am mistaken.