### PR TITLE
Remove unused constants.

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -46,15 +46,10 @@ namespace velodyne_rawdata
   static const int SCANS_PER_BLOCK = 32;
   static const int BLOCK_DATA_SIZE = (SCANS_PER_BLOCK * RAW_SCAN_SIZE);
 
-  static const float ROTATION_RESOLUTION = 0.01f; /**< degrees */
-  static const uint16_t ROTATION_MAX_UNITS = 36000; /**< hundredths of degrees */
+  static const float ROTATION_RESOLUTION      =     0.01f;  // [deg]
+  static const uint16_t ROTATION_MAX_UNITS    = 36000u;     // [deg/100]
+  static const float DISTANCE_RESOLUTION      =     0.002f; // [m]
 
-  /** According to Bruce Hall DISTANCE_MAX is 65.0, but we noticed
-   *  valid packets with readings up to 130.0. */
-  static const float DISTANCE_MAX = 130.0f;        /**< meters */
-  static const float DISTANCE_RESOLUTION = 0.002f; /**< meters */
-  static const float DISTANCE_MAX_UNITS = (DISTANCE_MAX
-                                           / DISTANCE_RESOLUTION + 1.0);
   /** @todo make this work for both big and little-endian machines */
   static const uint16_t UPPER_BANK = 0xeeff;
   static const uint16_t LOWER_BANK = 0xddff;


### PR DESCRIPTION
DISTANCE_MAX and DISTANCE_MAX_UNITS are not used anywhere in the code.

Furthermore, using them would lead to errors as both VLP-64 manuals state that returns above 120 m should not be used. The VLP-32 manual allows 70 m as the maximum valid sensor range.