### PR TITLE
Added an interface to set up raw data processing offline

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -133,6 +133,19 @@ namespace velodyne_rawdata
      */
     int setup(ros::NodeHandle private_nh);
 
+    /** \brief Set up for data processing offline. 
+      * Performs the same initialization as in setup, in the abscence of a ros::NodeHandle.
+      * this method is useful if unpacking data directly from bag files, without passing 
+      * through a communication overhead.
+      * 
+      * @param calibration_file path to the calibration file
+      * @param max_range_ cutoff for maximum range
+      * @param min_range_ cutoff for minimum range
+      * @returns 0 if successful;
+      *           errno value for failure
+     */
+    int setupOffline(std::string calibration_file, double max_range_, double min_range_);
+
     void unpack(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     
     void setParameters(double min_range, double max_range, double view_direction,


### PR DESCRIPTION
At our lab we have had this local change for a while now and thought it might be useful to push out. It's a small tweak to allow us to setup the driver for offline processing from a locally defined calibration file. This method is useful when processing data offline from a bag file, without starting any ros master.