### PR TITLE
[#121] Make PCL wrapper compatible with template classes

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/point_types.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/point_types.h
@@ -19,6 +19,13 @@
 #ifndef __VELODYNE_POINTCLOUD_POINT_TYPES_H
 #define __VELODYNE_POINTCLOUD_POINT_TYPES_H
 
+#define PCL_NO_PRECOMPILE
+#include <pcl/pcl_base.h>
+#include <pcl/impl/pcl_base.hpp>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/impl/passthrough.hpp>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/kdtree/impl/kdtree_flann.hpp>
 #include <pcl/point_types.h>
 
 namespace velodyne_pointcloud


### PR DESCRIPTION
This adds the needed includes to interoperate with approximate k-Nearest Neighbours, using PCLBase, and Passthrough filters in PCL.