### PR TITLE
Modern pluginlib macro

### DIFF
--- a/velodyne_driver/src/driver/nodelet.cc
+++ b/velodyne_driver/src/driver/nodelet.cc
@@ -81,6 +81,5 @@ void DriverNodelet::devicePoll()
 
 // Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_driver, DriverNodelet,
-                        velodyne_driver::DriverNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_driver::DriverNodelet, nodelet::Nodelet)

--- a/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/cloud_nodelet.cc
@@ -42,8 +42,7 @@ namespace velodyne_pointcloud
 } // namespace velodyne_pointcloud
 
 
-// Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
+// Register this plugin with pluginlib.  Names must match nodelets.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, CloudNodelet,
-                        velodyne_pointcloud::CloudNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::CloudNodelet, nodelet::Nodelet)

--- a/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/ringcolors_nodelet.cc
@@ -43,8 +43,7 @@ namespace velodyne_pointcloud
 } // namespace velodyne_pointcloud
 
 
-// Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
+// Register this plugin with pluginlib.  Names must match nodelets.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, RingColorsNodelet,
-                        velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::RingColorsNodelet, nodelet::Nodelet)

--- a/velodyne_pointcloud/src/conversions/transform_nodelet.cc
+++ b/velodyne_pointcloud/src/conversions/transform_nodelet.cc
@@ -42,9 +42,7 @@ namespace velodyne_pointcloud
 } // namespace velodyne_pointcloud
 
 
-// Register this plugin with pluginlib.  Names must match nodelet_velodyne.xml.
+// Register this plugin with pluginlib.  Names must match nodelets.xml.
 //
-// parameters: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(velodyne_pointcloud, TransformNodelet,
-                        velodyne_pointcloud::TransformNodelet,
-                        nodelet::Nodelet);
+// parameters: class type, base class type
+PLUGINLIB_EXPORT_CLASS(velodyne_pointcloud::TransformNodelet, nodelet::Nodelet)


### PR DESCRIPTION
PLUGINLIB_DECLARE_CLASS has been deprecated in favor of PLUGINLIB_EXPORT_CLASS
http://wiki.ros.org/pluginlib#pluginlib.2BAC8-pluginlib_groovy.Simplified_Export_Macro