### PR TITLE
Bugfix: when no device ip is set, we still want to filter by udp port.

### DIFF
--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -278,9 +278,8 @@ namespace velodyne_driver
           {
             // Skip packets not for the correct port and from the
             // selected IP address.
-            if (!devip_str_.empty() &&
-                (0 == pcap_offline_filter(&pcap_packet_filter_,
-                                          header, pkt_data)))
+            if (0 == pcap_offline_filter(&pcap_packet_filter_,
+                                          header, pkt_data))
               continue;
 
             // Keep the reader from blowing through the file.


### PR DESCRIPTION
Theres a bug when playing back pcap files that contain packets from another udp port (!= 2368). The pcap filter is not applied when the device ip is not set, which leads to incorrect playback of the file.