### PR TITLE
Use std::abs instead of abs

### DIFF
--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -283,7 +283,7 @@ namespace velodyne_rawdata
                              * (1 - corrections.focal_distance / 13100) 
                              * (1 - corrections.focal_distance / 13100);
           float focal_slope = corrections.focal_slope;
-          intensity += focal_slope * (abs(focal_offset - 256 * 
+          intensity += focal_slope * (std::abs(focal_offset - 256 * 
             (1 - static_cast<float>(tmp.uint)/65535)*(1 - static_cast<float>(tmp.uint)/65535)));
           intensity = (intensity < min_intensity) ? min_intensity : intensity;
           intensity = (intensity > max_intensity) ? max_intensity : intensity;
@@ -462,7 +462,7 @@ namespace velodyne_rawdata
                                * (1 - corrections.focal_distance / 13100) 
                                * (1 - corrections.focal_distance / 13100);
             float focal_slope = corrections.focal_slope;
-            intensity += focal_slope * (abs(focal_offset - 256 * 
+            intensity += focal_slope * (std::abs(focal_offset - 256 * 
               (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
             intensity = (intensity < min_intensity) ? min_intensity : intensity;
             intensity = (intensity > max_intensity) ? max_intensity : intensity;


### PR DESCRIPTION
abs is the c version which returns an integer. This is probably not intended here, so use the templated std::abs function.