### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/velodyne_laserscan/src/nodelet.cpp
+++ b/velodyne_laserscan/src/nodelet.cpp
@@ -21,4 +21,4 @@ private:
 
 }
 
-PLUGINLIB_DECLARE_CLASS(velodyne_laserscan, LaserScanNodelet, velodyne_laserscan::LaserScanNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(velodyne_laserscan::LaserScanNodelet, nodelet::Nodelet);


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions