### PR TITLE
Portable handling of ECANCELED

### DIFF
--- a/velodyne_gps_imu/src/gpsimu_driver.cc
+++ b/velodyne_gps_imu/src/gpsimu_driver.cc
@@ -90,7 +90,7 @@ void GpsImuDriver::handleSocketRead(const boost::system::error_code &error, std:
   }
   else
   {
-      if( error.value() != 995 )
+      if( error != boost::asio::error::operation_aborted )
       {
         std::cerr << "ERROR: " << "data connection error: " << error.message() << "(" << error.value() << ")" << std::endl;
         std::cout << "Trying to rebind socket" << std::endl;


### PR DESCRIPTION
On my machine (Ubuntu) the error code 995 does not mean a thing.

I hope I translated it correctly to the corresponding Boost.Asio code...