### PR TITLE
Fixed sign error in return value of InputSocket::getPacket()

### DIFF
--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -151,19 +151,19 @@ namespace velodyne_driver
               {
                 if (errno != EINTR)
                   ROS_ERROR("poll() error: %s", strerror(errno));
-                return 1;
+                return -1;
               }
             if (retval == 0)            // poll() timeout?
               {
                 ROS_WARN("Velodyne poll() timeout");
-                return 1;
+                return -1;
               }
             if ((fds[0].revents & POLLERR)
                 || (fds[0].revents & POLLHUP)
                 || (fds[0].revents & POLLNVAL)) // device error?
               {
                 ROS_ERROR("poll() reports Velodyne error");
-                return 1;
+                return -1;
               }
           } while ((fds[0].revents & POLLIN) == 0);
 
@@ -180,7 +180,7 @@ namespace velodyne_driver
               {
                 perror("recvfail");
                 ROS_INFO("recvfail");
-                return 1;
+                return -1;
               }
           }
         else if ((size_t) nbytes == packet_size)


### PR DESCRIPTION
The positive error code that is returned here is not properly handled in the driver.

Now a negative value is returned to indicate an error, as it is also done in InputPCAP::getPacket().