### PR TITLE
Fix malformed plugin description XML

### DIFF
--- a/velodyne_pointcloud/nodelets.xml
+++ b/velodyne_pointcloud/nodelets.xml
@@ -1,31 +1,35 @@
-<library path="lib/libcloud_nodelet">
-  <class name="velodyne_pointcloud/CloudNodelet"
-         type="velodyne_pointcloud::CloudNodelet"
-         base_class_type="nodelet::Nodelet">
-    <description>
-      Aggregates points from multiple packets, publishing PointCloud2.
-    </description>
-  </class>
-</library>
+<class_libraries>
 
-<library path="lib/libringcolors_nodelet">
-  <class name="velodyne_pointcloud/RingColorsNodelet"
-         type="velodyne_pointcloud::RingColorsNodelet"
-         base_class_type="nodelet::Nodelet">
-    <description>
-      Converts a Velodyne PointCloud2 to PointXYZRGB, assigning colors
-      for visualization of the laser rings.
-    </description>
-  </class>
-</library>
+  <library path="lib/libcloud_nodelet">
+    <class name="velodyne_pointcloud/CloudNodelet"
+           type="velodyne_pointcloud::CloudNodelet"
+           base_class_type="nodelet::Nodelet">
+      <description>
+        Aggregates points from multiple packets, publishing PointCloud2.
+      </description>
+    </class>
+  </library>
 
-<library path="lib/libtransform_nodelet">
-  <class name="velodyne_pointcloud/TransformNodelet"
-         type="velodyne_pointcloud::TransformNodelet"
-         base_class_type="nodelet::Nodelet">
-    <description>
-      Transforms packets into /odom frame, publishing multiple packets
-      as PointCloud2.
-    </description>
-  </class>
-</library>
+  <library path="lib/libringcolors_nodelet">
+    <class name="velodyne_pointcloud/RingColorsNodelet"
+           type="velodyne_pointcloud::RingColorsNodelet"
+           base_class_type="nodelet::Nodelet">
+      <description>
+        Converts a Velodyne PointCloud2 to PointXYZRGB, assigning colors
+        for visualization of the laser rings.
+      </description>
+    </class>
+  </library>
+
+  <library path="lib/libtransform_nodelet">
+    <class name="velodyne_pointcloud/TransformNodelet"
+           type="velodyne_pointcloud::TransformNodelet"
+           base_class_type="nodelet::Nodelet">
+      <description>
+        Transforms packets into /odom frame, publishing multiple packets
+        as PointCloud2.
+      </description>
+    </class>
+  </library>
+
+</class_libraries>


### PR DESCRIPTION
ROS pluginlib only recognizes multiple <library> elements if they are under
<class_libraries> XML root. It silently ignores malformed XMLs with multiple
<library> "root"s and just reads the first one, due to relaxed way tinyxml2 does
parsing. Though if you do `rosrun nodelet declared_nodelets`, the issue is
reported properly.

See also similar issue in https://github.com/ros-perception/perception_pcl/issues/131