### PR TITLE
Transform static variable into member

### DIFF
--- a/velodyne_driver/include/velodyne_driver/driver.h
+++ b/velodyne_driver/include/velodyne_driver/driver.h
@@ -62,6 +62,7 @@ private:
 
   boost::shared_ptr<Input> input_;
   ros::Publisher output_;
+  int last_azimuth_;
 
   /** diagnostics updater */
   ros::Timer diag_timer_;


### PR DESCRIPTION
I had problems running multiple drivers when I used a nodelet manager. So I turned 'last_azimuth' into a member, which solved the issue for me. Also it's a cleaner design.