### PR TITLE
Use time within the packet

### DIFF
--- a/velodyne_driver/CMakeLists.txt
+++ b/velodyne_driver/CMakeLists.txt
@@ -75,4 +75,9 @@ if (CATKIN_ENABLE_TESTING)
   # parse check all the launch/*.launch files
   roslaunch_add_file_check(launch)
 
+  # unit test
+  catkin_add_gtest(time_test tests/timeconversiontest.cpp)
+  target_link_libraries(time_test
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES})
 endif (CATKIN_ENABLE_TESTING)

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -67,6 +67,7 @@ namespace velodyne_driver
     ros::NodeHandle private_nh_;
     uint16_t port_;
     std::string devip_str_;
+    bool gps_time_;
   };
 
   /** @brief Live Velodyne input from socket. */

--- a/velodyne_driver/include/velodyne_driver/time_conversion.hpp
+++ b/velodyne_driver/include/velodyne_driver/time_conversion.hpp
@@ -1,0 +1,46 @@
+#ifndef VELODYNE_DRIVER_TIME_CONVERSION_HPP
+#define VELODYNE_DRIVER_TIME_CONVERSION_HPP
+
+#include <ros/ros.h>
+#include <ros/time.h>
+
+/** @brief Function used to check that hour assigned to timestamp in conversion is
+ * correct. Velodyne only returns time since the top of the hour, so if the computer clock
+ * and the velodyne clock (gps-synchronized) are a little off, there is a chance the wrong
+ * hour may be associated with the timestamp
+ * 
+ * @param stamp timestamp recovered from velodyne
+ * @param nominal_stamp time coming from computer's clock
+ * @return timestamp from velodyne, possibly shifted by 1 hour if the function arguments
+ * disagree by more than a half-hour.
+ */
+ros::Time resolveHourAmbiguity(const ros::Time &stamp, const ros::Time &nominal_stamp) {
+    const int HALFHOUR_TO_SEC = 1800;
+    ros::Time retval = stamp;
+    if (nominal_stamp.sec > stamp.sec) {
+        if (nominal_stamp.sec - stamp.sec > HALFHOUR_TO_SEC) {
+            retval.sec = retval.sec + 2*HALFHOUR_TO_SEC;
+        }
+    } else if (stamp.sec - nominal_stamp.sec > HALFHOUR_TO_SEC) {
+        retval.sec = retval.sec - 2*HALFHOUR_TO_SEC;
+    }
+    return retval;
+}
+
+ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data) {
+    const int HOUR_TO_SEC = 3600;
+    // time for each packet is a 4 byte uint
+    // It is the number of microseconds from the top of the hour
+    uint32_t usecs = (uint32_t) ( ((uint32_t) data[3]) << 24 |
+                                  ((uint32_t) data[2] ) << 16 |
+                                  ((uint32_t) data[1] ) << 8 |
+                                  ((uint32_t) data[0] ));
+    ros::Time time_nom = ros::Time::now(); // use this to recover the hour
+    uint32_t cur_hour = time_nom.sec / HOUR_TO_SEC;
+    ros::Time stamp = ros::Time((cur_hour * HOUR_TO_SEC) + (usecs / 1000000),
+                                (usecs % 1000000) * 1000);
+    stamp = resolveHourAmbiguity(stamp, time_nom);
+    return stamp;
+}
+
+#endif //VELODYNE_DRIVER_TIME_CONVERSION_HPP

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -13,6 +13,7 @@
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
 
   <!-- start nodelet manager -->
@@ -30,6 +31,7 @@
     <param name="read_once" value="$(arg read_once)"/>
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
     <param name="rpm" value="$(arg rpm)"/>
+    <param name="gps_time" value="$(arg gps_time)"/>
     <param name="cut_angle" value="$(arg cut_angle)"/>
   </node>    
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <sys/file.h>
 #include <velodyne_driver/input.h>
+#include <velodyne_driver/time_conversion.hpp>
 
 namespace velodyne_driver
 {
@@ -199,10 +200,9 @@ namespace velodyne_driver
                          << nbytes << " bytes");
       }
 
-    // Average the times at which we begin and end reading.  Use that to
-    // estimate when the scan occurred. Add the time offset.
-    double time2 = ros::Time::now().toSec();
-    pkt->stamp = ros::Time((time2 + time1) / 2.0 + time_offset);
+    // time for each packet is a 4 byte uint located starting at offset 1200 in
+    // the data packet
+    pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]));
 
     return 0;
   }

--- a/velodyne_driver/tests/timeconversiontest.cpp
+++ b/velodyne_driver/tests/timeconversiontest.cpp
@@ -1,0 +1,29 @@
+#include "velodyne_driver/time_conversion.hpp"
+#include <ros/time.h>
+#include <gtest/gtest.h>
+
+TEST(TimeConversion, BytesToTimestamp) {
+    ros::Time::init();
+    ros::Time ros_stamp = ros::Time::now();
+
+    // get the seconds past the hour and multiply by 1million to convert to microseconds
+    // divide nanoseconds by 1000 to convert to microseconds
+    uint32_t since_the_hour = ((ros_stamp.sec % 3600) * 1000000) + ros_stamp.nsec / 1000;
+
+    uint8_t native_format[4];
+    native_format[0] = 0xFF & since_the_hour;
+    native_format[1] = 0xFF & (((uint32_t)since_the_hour) >> 8);
+    native_format[2] = 0xFF & (((uint32_t)since_the_hour) >> 16);
+    native_format[3] = 0xFF & (((uint32_t)since_the_hour) >> 24);
+
+    ros::Time ros_stamp_converted = rosTimeFromGpsTimestamp(native_format);
+
+    ASSERT_EQ(ros_stamp_converted.sec, ros_stamp.sec);
+    ASSERT_NEAR(ros_stamp_converted.nsec, ros_stamp.nsec, 1000);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -16,6 +16,7 @@
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -32,6 +33,7 @@
     <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/64e_S3.launch
+++ b/velodyne_pointcloud/launch/64e_S3.launch
@@ -16,6 +16,7 @@
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -33,6 +34,7 @@
     <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/VLP-32C_points.launch
+++ b/velodyne_pointcloud/launch/VLP-32C_points.launch
@@ -16,6 +16,7 @@
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
 
@@ -31,6 +32,7 @@
     <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="gps_time" value="$(arg gps_time)"/>
   </include>
 
   <!-- start cloud nodelet -->

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -16,6 +16,7 @@
   <arg name="read_once" default="false" />
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
+  <arg name="gps_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -32,6 +33,7 @@
     <arg name="read_once" value="$(arg read_once)"/>
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
+    <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
   </include>
 


### PR DESCRIPTION
I'm opening up a couple of PRs for changes we have made to our internal driver so that we can use the public driver again.

This is the first one and it will increase the accuracy of the ros message timestamp by using the GPS provided time. I'm thinking I could add a param to the launch files to enable GPS time instead of removed the prior functionality?