### PR TITLE
Added diagnostic publishing

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -12,6 +12,7 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     velodyne_driver
     velodyne_msgs
     dynamic_reconfigure
+    diagnostic_updater
 )
 
 find_package(catkin REQUIRED COMPONENTS
@@ -39,7 +40,7 @@ if(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
   add_definitions(-DHAVE_NEW_YAMLCPP)
 endif(NOT ${YAML_CPP_VERSION} VERSION_LESS "0.5")
 
-include_directories(include ${catkin_INCLUDE_DIRS} 
+include_directories(include ${catkin_INCLUDE_DIRS}
   ${dynamic_reconfigure_PACKAGE_PATH}/cmake/cfgbuild.cmake
 )
 
@@ -47,7 +48,7 @@ catkin_package(
     CATKIN_DEPENDS ${${PROJECT_NAME}_CATKIN_DEPS}
     INCLUDE_DIRS include
     LIBRARIES velodyne_rawdata)
-    
+
 #add_executable(dynamic_reconfigure_node src/dynamic_reconfigure_node.cpp)
 #target_link_libraries(dynamic_reconfigure_node
 #   ${catkin_LIBRARIES}
@@ -66,7 +67,7 @@ install(DIRECTORY params/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/params)
 install(PROGRAMS scripts/gen_calibration.py
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-  
+
 
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(tests)

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -18,6 +18,8 @@
 #define _VELODYNE_POINTCLOUD_CONVERT_H_ 1
 
 #include <ros/ros.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
 
 #include <sensor_msgs/PointCloud2.h>
 #include <velodyne_pointcloud/rawdata.h>
@@ -36,7 +38,7 @@ namespace velodyne_pointcloud
     ~Convert() {}
 
   private:
-    
+
     void callback(velodyne_pointcloud::CloudNodeConfig &config,
                 uint32_t level);
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
@@ -44,7 +46,7 @@ namespace velodyne_pointcloud
     ///Pointer to dynamic reconfigure service srv_
     boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::
       CloudNodeConfig> > srv_;
-    
+
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     ros::Subscriber velodyne_scan_;
     ros::Publisher output_;
@@ -53,7 +55,13 @@ namespace velodyne_pointcloud
     typedef struct {
       int npackets;                    ///< number of packets to combine
     } Config;
-    Config config_;    
+    Config config_;
+
+    // diagnostics updater
+    diagnostic_updater::Updater diagnostics_;
+    double diag_min_freq_;
+    double diag_max_freq_;
+    boost::shared_ptr<diagnostic_updater::TopicDiagnostic> diag_topic_;
   };
 
 } // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -21,6 +21,8 @@
 #include <ros/ros.h>
 #include "tf/message_filter.h"
 #include "message_filters/subscriber.h"
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
 #include <sensor_msgs/PointCloud2.h>
 
 #include <velodyne_pointcloud/rawdata.h>
@@ -74,8 +76,14 @@ namespace velodyne_pointcloud
     // Point cloud buffers for collecting points within a packet.  The
     // inPc_ and tfPc_ are class members only to avoid reallocation on
     // every message.
-    PointcloudXYZIR inPc_;              ///< input packet point cloud
-    velodyne_rawdata::VPointCloud tfPc_;              ///< transformed packet point cloud
+    PointcloudXYZIR inPc_;                ///< input packet point cloud
+    velodyne_rawdata::VPointCloud tfPc_;  ///< transformed packet point cloud
+
+    // diagnostics updater
+    diagnostic_updater::Updater diagnostics_;
+    double diag_min_freq_;
+    double diag_max_freq_;
+    boost::shared_ptr<diagnostic_updater::TopicDiagnostic> diag_topic_;
   };
 
 } // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/package.xml
+++ b/velodyne_pointcloud/package.xml
@@ -29,6 +29,7 @@
   <depend>velodyne_msgs</depend>
   <depend>yaml-cpp</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>diagnostic_updater</depend>
 
   <exec_depend>velodyne_laserscan</exec_depend>
 

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -49,6 +49,19 @@ namespace velodyne_pointcloud
                                                          listener_,
                                                          config_.frame_id, 10);
     tf_filter_->registerCallback(boost::bind(&Transform::processScan, this, _1));
+
+    // Diagnostics
+    diagnostics_.setHardwareID("Velodyne Transform");
+    // Arbitrary frequencies since we don't know which RPM is used, and are only
+    // concerned about monitoring the frequency.
+    diag_min_freq_ = 2.0;
+    diag_max_freq_ = 20.0;
+    using namespace diagnostic_updater;
+    diag_topic_.reset(new TopicDiagnostic("velodyne_points", diagnostics_,
+                                          FrequencyStatusParam(&diag_min_freq_,
+                                                               &diag_max_freq_,
+                                                               0.1, 10),
+                                          TimeStampStatusParam()));
   }
   
   void Transform::reconfigure_callback(
@@ -133,6 +146,8 @@ namespace velodyne_pointcloud
     ROS_DEBUG_STREAM("Publishing " << outMsg->height * outMsg->width
                      << " Velodyne points, time: " << outMsg->header.stamp);
     output_.publish(outMsg);
+    diag_topic_->tick(scanMsg->header.stamp);
+    diagnostics_.update();
   }
 
 } // namespace velodyne_pointcloud


### PR DESCRIPTION
I'm opening up a couple of PRs for changes we have made to our internal driver so that we can use the public driver again.

This is the last one. This PR adds publishing of diagnostic information. It should be useful to run on a bag with packets to compare performance when changes are made to the convert or transform files. 

Here is an example screenshot:
![image](https://user-images.githubusercontent.com/3324075/55087047-d3715780-507f-11e9-9748-79e15a30ad01.png)
