### PR TITLE
Fix dead pointers in calibration.cc

### DIFF
--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -89,7 +89,7 @@ namespace velodyne_pointcloud
     const YAML::Node * max_intensity_node = NULL;
 #ifdef HAVE_NEW_YAMLCPP
     if (node[MAX_INTENSITY]) {
-      const YAML::Node max_intensity_node_ref = node[MAX_INTENSITY];
+      const YAML::Node &max_intensity_node_ref = node[MAX_INTENSITY];
       max_intensity_node = &max_intensity_node_ref;
     }
 #else
@@ -108,7 +108,7 @@ namespace velodyne_pointcloud
     const YAML::Node * min_intensity_node = NULL;
 #ifdef HAVE_NEW_YAMLCPP
     if (node[MIN_INTENSITY]) {
-      const YAML::Node min_intensity_node_ref = node[MIN_INTENSITY];
+      const YAML::Node &min_intensity_node_ref = node[MIN_INTENSITY];
       min_intensity_node = &min_intensity_node_ref;
     }
 #else


### PR DESCRIPTION
There are two places in calibration.cc where a temporary object is created, a pointer to that object is stored, the object goes out of scope, and then the pointer is dereferenced. This fix replaces the temporary objects with const references so the resulting pointers are valid.