### PR TITLE
driver: add enabled reconfigure param

### DIFF
--- a/velodyne_driver/cfg/VelodyneNode.cfg
+++ b/velodyne_driver/cfg/VelodyneNode.cfg
@@ -8,7 +8,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("time_offset", double_t,  0, "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",
+gen.add("time_offset", double_t,  1, "A manually calibrated offset (in seconds) to add to the timestamp before publication of a message.",
         0.0, -1.0, 1.0)
+gen.add("enabled", bool_t, 2, "Switch to enable and disable lidar packet consumption", True);
 
 exit(gen.generate(PACKAGE, NODE_NAME, PARAMS_NAME))

--- a/velodyne_driver/include/velodyne_driver/driver.h
+++ b/velodyne_driver/include/velodyne_driver/driver.h
@@ -74,6 +74,7 @@ private:
     double rpm;                      // device rotation rate (RPMs)
     int cut_angle;                   // cutting angle in 1/100°
     double time_offset;              // time in seconds added to each velodyne time stamp
+    bool enabled;                    // polling is enabled
   }
   config_;
 


### PR DESCRIPTION
This will allow polling to be disabled when the device has been disabled
in some way. Specifically this is interesting when the rpm is set to 0
when not is use. This also adds a mask value for the time_offset so that
it won't be touched if it wasn't reconfigured.