### PR TITLE
bug fix for row step

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -67,7 +67,7 @@ public:
     }
     va_end(vl);
     cloud.point_step = offset;
-    cloud.row_step = cloud.width * cloud.point_step;
+    cloud.row_step = init_width * cloud.point_step;
     if (config_.transform && !tf_ptr)
     {
       tf_ptr = boost::shared_ptr<tf::TransformListener>(new tf::TransformListener);


### PR DESCRIPTION
As "cloud.width" has not been assigned, it is 0 here, which makes "cloud.row_step" 0. Another option is moving the calculation of "cloud.row_step"  to function "setup".