### PR TITLE
Dashing: Start removing node handle from input.cc

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -126,7 +126,10 @@ public:
             const std::string & devip,
             uint16_t port,
             double packet_rate,
-            const std::string & filename);
+            const std::string & filename,
+            bool read_once,
+            bool read_fast,
+            double repeat_delay);
   virtual ~InputPCAP();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -126,7 +126,7 @@ public:
             const std::string & devip,
             uint16_t port,
             double packet_rate,
-            std::string filename);
+            const std::string & filename);
   virtual ~InputPCAP();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -93,7 +93,6 @@ protected:
   rclcpp::Node * private_nh_;
   uint16_t port_;
   std::string devip_str_;
-  bool gps_time_;
 };
 
 /** @brief Live Velodyne input from socket. */
@@ -101,7 +100,7 @@ class InputSocket: public Input
 {
 public:
   InputSocket(rclcpp::Node * private_nh,
-              uint16_t port);
+              uint16_t port, bool gps_time);
   virtual ~InputSocket();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
@@ -111,6 +110,7 @@ public:
 private:
   int sockfd_;
   in_addr devip_;
+  bool gps_time_;
 };
 
 

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -75,7 +75,7 @@ constexpr uint16_t DATA_PORT_NUMBER = 2368;      // default data port
 class Input
 {
 public:
-  Input(rclcpp::Node * private_nh, uint16_t port);
+  Input(rclcpp::Node * private_nh, const std::string & devip, uint16_t port);
   virtual ~Input() {}
 
   /** @brief Read one Velodyne packet.
@@ -91,8 +91,8 @@ public:
 
 protected:
   rclcpp::Node * private_nh_;
-  uint16_t port_;
   std::string devip_str_;
+  uint16_t port_;
 };
 
 /** @brief Live Velodyne input from socket. */
@@ -100,7 +100,7 @@ class InputSocket: public Input
 {
 public:
   InputSocket(rclcpp::Node * private_nh,
-              uint16_t port, bool gps_time);
+              const std::string & devip, uint16_t port, bool gps_time);
   virtual ~InputSocket();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
@@ -123,6 +123,7 @@ class InputPCAP: public Input
 {
 public:
   InputPCAP(rclcpp::Node * private_nh,
+            const std::string & devip,
             uint16_t port,
             double packet_rate,
             std::string filename);

--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -69,7 +69,7 @@
 namespace velodyne_driver
 {
 
-static uint16_t DATA_PORT_NUMBER = 2368;      // default data port
+constexpr uint16_t DATA_PORT_NUMBER = 2368;      // default data port
 
 /** @brief Velodyne input base class */
 class Input
@@ -101,7 +101,7 @@ class InputSocket: public Input
 {
 public:
   InputSocket(rclcpp::Node * private_nh,
-              uint16_t port = DATA_PORT_NUMBER);
+              uint16_t port);
   virtual ~InputSocket();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
@@ -123,9 +123,9 @@ class InputPCAP: public Input
 {
 public:
   InputPCAP(rclcpp::Node * private_nh,
-            uint16_t port = DATA_PORT_NUMBER,
-            double packet_rate = 0.0,
-            std::string filename = "");
+            uint16_t port,
+            double packet_rate,
+            std::string filename);
   virtual ~InputPCAP();
 
   virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -69,9 +69,9 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
   config_.time_offset = this->declare_parameter("time_offset", 0.0, offset_desc);
 
   config_.enabled = this->declare_parameter("enabled", true);
-  this->declare_parameter("read_once", false);
-  this->declare_parameter("read_fast", false);
-  this->declare_parameter("repeat_delay", 0.0);
+  bool read_once = this->declare_parameter("read_once", false);
+  bool read_fast = this->declare_parameter("read_fast", false);
+  double repeat_delay = this->declare_parameter("repeat_delay", 0.0);
   config_.frame_id = this->declare_parameter("frame_id", std::string("velodyne"));
   config_.model = this->declare_parameter("model", std::string("64E"));
   config_.rpm = this->declare_parameter("rpm", 600.0);
@@ -170,7 +170,7 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
     {
       // read data from packet capture file
       input_.reset(new velodyne_driver::InputPCAP(this, devip, udp_port,
-                                                  packet_rate, dump_file));
+                                                  packet_rate, dump_file, read_once, read_fast, repeat_delay));
     }
   else
     {

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -55,7 +55,7 @@ namespace velodyne_driver
 
 VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
 {
-  this->declare_parameter("device_ip", std::string(""));
+  std::string devip = this->declare_parameter("device_ip", std::string(""));
   bool gps_time = this->declare_parameter("gps_time", false);
 
   rcl_interfaces::msg::ParameterDescriptor offset_desc;
@@ -169,13 +169,13 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
   if (dump_file != "")                  // have PCAP file?
     {
       // read data from packet capture file
-      input_.reset(new velodyne_driver::InputPCAP(this, udp_port,
+      input_.reset(new velodyne_driver::InputPCAP(this, devip, udp_port,
                                                   packet_rate, dump_file));
     }
   else
     {
       // read data from live socket
-      input_.reset(new velodyne_driver::InputSocket(this, udp_port, gps_time));
+      input_.reset(new velodyne_driver::InputSocket(this, devip, udp_port, gps_time));
     }
 
   // raw packet output topic

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -56,7 +56,7 @@ namespace velodyne_driver
 VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
 {
   this->declare_parameter("device_ip", std::string(""));
-  this->declare_parameter("gps_time", false);
+  bool gps_time = this->declare_parameter("gps_time", false);
 
   rcl_interfaces::msg::ParameterDescriptor offset_desc;
   offset_desc.name = "time_offset";
@@ -175,7 +175,7 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
   else
     {
       // read data from live socket
-      input_.reset(new velodyne_driver::InputSocket(this, udp_port));
+      input_.reset(new velodyne_driver::InputSocket(this, udp_port, gps_time));
     }
 
   // raw packet output topic

--- a/velodyne_driver/src/driver/velodyne_node.cc
+++ b/velodyne_driver/src/driver/velodyne_node.cc
@@ -41,7 +41,7 @@
 int main(int argc, char** argv)
 {
   // Force flush of the stdout buffer.
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
   rclcpp::init(argc, argv);
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -278,11 +278,11 @@ namespace velodyne_driver
     Input(private_nh, devip, port),
     packet_rate_(packet_rate),
     filename_(filename),
+    pcap_(nullptr),
     read_once_(read_once),
     read_fast_(read_fast),
     repeat_delay_(repeat_delay)
   {
-    pcap_ = NULL;
     empty_ = true;
 
     if (read_once_)
@@ -301,7 +301,7 @@ namespace velodyne_driver
 
     // Open the PCAP dump file
     RCLCPP_INFO(private_nh->get_logger(), "Opening PCAP file \"%s\"", filename_.c_str());
-    if ((pcap_ = pcap_open_offline(filename_.c_str(), errbuf_) ) == NULL)
+    if ((pcap_ = pcap_open_offline(filename_.c_str(), errbuf_) ) == nullptr)
       {
         RCLCPP_FATAL(private_nh->get_logger(), "Error opening Velodyne socket dump file.");
         return;

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -73,13 +73,14 @@ namespace velodyne_driver
   /** @brief constructor
    *
    *  @param private_nh ROS node handle for calling node.
+   *  @param devip Device IP address.
    *  @param port UDP port number.
    */
-  Input::Input(rclcpp::Node * private_nh, uint16_t port):
+  Input::Input(rclcpp::Node * private_nh, const std::string & devip, uint16_t port):
     private_nh_(private_nh),
+    devip_str_(devip),
     port_(port)
   {
-    private_nh->get_parameter("device_ip", devip_str_);
     if (!devip_str_.empty())
       {
         RCLCPP_INFO(private_nh->get_logger(), "Only accepting packets from IP address: "
@@ -94,10 +95,11 @@ namespace velodyne_driver
   /** @brief constructor
    *
    *  @param private_nh ROS private handle for calling node.
-   *  @param port UDP port number
+   *  @param devip Device IP address.
+   *  @param port UDP port number.
    */
-  InputSocket::InputSocket(rclcpp::Node * private_nh, uint16_t port, bool gps_time):
-    Input(private_nh, port), gps_time_(gps_time)
+  InputSocket::InputSocket(rclcpp::Node * private_nh, const std::string & devip, uint16_t port, bool gps_time):
+    Input(private_nh, devip, port), gps_time_(gps_time)
   {
     sockfd_ = -1;
 
@@ -223,7 +225,7 @@ namespace velodyne_driver
             // read successful,
             // if packet is not from the lidar scanner we selected by IP,
             // continue otherwise we are done
-            if (devip_str_ != ""
+            if (!devip_str_.empty()
                 && sender_address.sin_addr.s_addr != devip_.s_addr)
               {
                 continue;
@@ -263,13 +265,14 @@ namespace velodyne_driver
   /** @brief constructor
    *
    *  @param private_nh ROS private handle for calling node.
-   *  @param port UDP port number
-   *  @param packet_rate expected device packet frequency (Hz)
-   *  @param filename PCAP dump file name
+   *  @param devip Device IP address.
+   *  @param port UDP port number.
+   *  @param packet_rate expected device packet frequency (Hz).
+   *  @param filename PCAP dump file name.
    */
-  InputPCAP::InputPCAP(rclcpp::Node * private_nh, uint16_t port,
+  InputPCAP::InputPCAP(rclcpp::Node * private_nh, const std::string & devip, uint16_t port,
                        double packet_rate, std::string filename):
-    Input(private_nh, port),
+    Input(private_nh, devip, port),
     packet_rate_(packet_rate),
     filename_(filename)
   {
@@ -304,7 +307,7 @@ namespace velodyne_driver
       }
 
     std::stringstream filter;
-    if (devip_str_ != "")              // using specific IP?
+    if (!devip_str_.empty())              // using specific IP?
       {
         filter << "src host " << devip_str_ << " && ";
       }

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -269,20 +269,21 @@ namespace velodyne_driver
    *  @param port UDP port number.
    *  @param packet_rate expected device packet frequency (Hz).
    *  @param filename PCAP dump file name.
+   *  @param read_once Read the input file only once.
+   *  @param read_fast Output the data from the input file as fast as possible.
+   *  @param repeat_delay Seconds to wait between repeating input file.
    */
   InputPCAP::InputPCAP(rclcpp::Node * private_nh, const std::string & devip, uint16_t port,
-                       double packet_rate, const std::string & filename):
+                       double packet_rate, const std::string & filename, bool read_once, bool read_fast, double repeat_delay):
     Input(private_nh, devip, port),
     packet_rate_(packet_rate),
-    filename_(filename)
+    filename_(filename),
+    read_once_(read_once),
+    read_fast_(read_fast),
+    repeat_delay_(repeat_delay)
   {
     pcap_ = NULL;
     empty_ = true;
-
-    // get parameters using private node handle
-    private_nh->get_parameter("read_once", read_once_);
-    private_nh->get_parameter("read_fast", read_fast_);
-    private_nh->get_parameter("repeat_delay", repeat_delay_);
 
     if (read_once_)
       {

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -80,7 +80,6 @@ namespace velodyne_driver
     port_(port)
   {
     private_nh->get_parameter("device_ip", devip_str_);
-    private_nh->get_parameter("gps_time", gps_time_);
     if (!devip_str_.empty())
       {
         RCLCPP_INFO(private_nh->get_logger(), "Only accepting packets from IP address: "
@@ -97,8 +96,8 @@ namespace velodyne_driver
    *  @param private_nh ROS private handle for calling node.
    *  @param port UDP port number
    */
-  InputSocket::InputSocket(rclcpp::Node * private_nh, uint16_t port):
-    Input(private_nh, port)
+  InputSocket::InputSocket(rclcpp::Node * private_nh, uint16_t port, bool gps_time):
+    Input(private_nh, port), gps_time_(gps_time)
   {
     sockfd_ = -1;
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -271,7 +271,7 @@ namespace velodyne_driver
    *  @param filename PCAP dump file name.
    */
   InputPCAP::InputPCAP(rclcpp::Node * private_nh, const std::string & devip, uint16_t port,
-                       double packet_rate, std::string filename):
+                       double packet_rate, const std::string & filename):
     Input(private_nh, devip, port),
     packet_rate_(packet_rate),
     filename_(filename)

--- a/velodyne_pointcloud/src/conversions/convert_node.cc
+++ b/velodyne_pointcloud/src/conversions/convert_node.cc
@@ -21,7 +21,7 @@
 int main(int argc, char **argv)
 {
   // Force flush of the stdout buffer.
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
   rclcpp::init(argc, argv);
 

--- a/velodyne_pointcloud/src/conversions/transform_node.cc
+++ b/velodyne_pointcloud/src/conversions/transform_node.cc
@@ -21,6 +21,9 @@
 /** Main node entry point. */
 int main(int argc, char **argv)
 {
+  // Force flush of the stdout buffer.
+  setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
+
   rclcpp::init(argc, argv);
 
   // handle callbacks until shut down


### PR DESCRIPTION
Ideally, the classes in [input.cc](https://github.com/ros-drivers/velodyne/blob/dashing-devel/velodyne_driver/src/lib/input.cc) would have no knowledge of ROS at all.  This would make them more independent and able to be unit tested a bit more easily.  This PR goes some way towards doing that by removing all of the `get_parameter` calls in input.cc, and instead passes those values in when the classes are constructed.  After this PR, the only remaining uses for the node handle inside of `input.cc` is for the logging; I'll consider how to deal with that better later.