### PR TITLE
Remove a dead store from rawdata.cc.

### DIFF
--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -200,9 +200,6 @@ inline float SQR(float val) { return val*val; }
           continue;
         }
 
-        float distance = tmp.uint * calibration_.distance_resolution_m;
-        distance += corrections.dist_correction;
-
         /*condition added to avoid calculating points which are not
           in the interesting defined area (min_angle < area < max_angle)*/
         if ((block.rotation >= config_.min_angle


### PR DESCRIPTION
It looks like probably the result of a bad merge; the distance
variable is never used in the outer scope, so just remove it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>