### PR TITLE
Dashing: fixed timpepoint issue

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -173,8 +173,8 @@ protected:
     geometry_msgs::msg::TransformStamped transform;
     try
       {
-        std::chrono::nanoseconds dur(time.nanoseconds());
-        std::chrono::time_point<std::chrono::system_clock> time(dur);
+        const std::chrono::nanoseconds dur(time.nanoseconds());
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time(dur);
         transform = tf_buffer_.lookupTransform(config_.target_frame, cloud.header.frame_id, time);
       }
     catch (tf2::LookupException& e)


### PR DESCRIPTION
Wouldn't compile on MacOSX Mojave without this change. The default "ratio" is different when omitting the second template argument (nanoseconds).

Off topic: I've been trying to compile the past couple of weeks, without success. It's unfortunately not possible to compile with Mojave and Xcode. Needed to get rid of Xcode :( for it to work (same issue as seen here https://github.com/PointCloudLibrary/pcl/issues/2601#issuecomment-486889884 and in many other places online) I hope someone finds a solution for that soon...