### PR TITLE
Dashing: Remove redundant storage of configuration data

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -75,7 +75,7 @@ constexpr uint16_t DATA_PORT_NUMBER = 2368;      // default data port
 class Input
 {
 public:
-  Input(rclcpp::Node * private_nh, const std::string & devip, uint16_t port);
+  explicit Input(rclcpp::Node * private_nh, const std::string & devip, uint16_t port);
   virtual ~Input() {}
 
   /** @brief Read one Velodyne packet.
@@ -96,15 +96,15 @@ protected:
 };
 
 /** @brief Live Velodyne input from socket. */
-class InputSocket: public Input
+class InputSocket final : public Input
 {
 public:
-  InputSocket(rclcpp::Node * private_nh,
+  explicit InputSocket(rclcpp::Node * private_nh,
               const std::string & devip, uint16_t port, bool gps_time);
-  virtual ~InputSocket();
+  ~InputSocket();
 
-  virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
-                        const double time_offset);
+  int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
+                const double time_offset) override;
   void setDeviceIP(const std::string& ip);
 
 private:
@@ -119,21 +119,21 @@ private:
  * Dump files can be grabbed by libpcap, Velodyne's DSR software,
  * ethereal, wireshark, tcpdump, or the \ref vdump_command.
  */
-class InputPCAP: public Input
+class InputPCAP final : public Input
 {
 public:
-  InputPCAP(rclcpp::Node * private_nh,
-            const std::string & devip,
-            uint16_t port,
-            double packet_rate,
-            const std::string & filename,
-            bool read_once,
-            bool read_fast,
-            double repeat_delay);
-  virtual ~InputPCAP();
+  explicit InputPCAP(rclcpp::Node * private_nh,
+                     const std::string & devip,
+                     uint16_t port,
+                     double packet_rate,
+                     const std::string & filename,
+                     bool read_once,
+                     bool read_fast,
+                     double repeat_delay);
+  ~InputPCAP();
 
-  virtual int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
-                        const double time_offset);
+  int getPacket(velodyne_msgs::msg::VelodynePacket *pkt,
+                const double time_offset) override;
   void setDeviceIP(const std::string& ip);
 
 private:

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -105,7 +105,7 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
       packet_rate = 1808.0;
       model_full_name = std::string("HDL-") + config_.model;
     }
-    else if (config_.model == "32C")
+  else if (config_.model == "32C")
     {
       packet_rate = 1507.0;
       model_full_name = std::string("VLP-") + config_.model;
@@ -117,9 +117,9 @@ VelodyneDriver::VelodyneDriver() : rclcpp::Node("velodyne_driver_node")
     }
   else
     {
-      RCLCPP_ERROR(this->get_logger(), "unknown Velodyne LIDAR model: " + config_.model);
-      packet_rate = 2600.0;
+      throw std::runtime_error("Unknown Velodyne LIDAR model: " + config_.model);
     }
+
   std::string deviceName(std::string("Velodyne ") + model_full_name);
 
   RCLCPP_INFO(this->get_logger(), "%s rotating at %f RPM", deviceName.c_str(), config_.rpm);

--- a/velodyne_laserscan/include/velodyne_laserscan/velodyne_laserscan.h
+++ b/velodyne_laserscan/include/velodyne_laserscan/velodyne_laserscan.h
@@ -40,7 +40,7 @@
 namespace velodyne_laserscan
 {
 
-class VelodyneLaserScan : public rclcpp::Node
+class VelodyneLaserScan final : public rclcpp::Node
 {
 public:
   VelodyneLaserScan();

--- a/velodyne_laserscan/src/velodyne_laserscan.cpp
+++ b/velodyne_laserscan/src/velodyne_laserscan.cpp
@@ -223,13 +223,7 @@ void VelodyneLaserScan::recvCallback(const sensor_msgs::msg::PointCloud2::Shared
         }
       else
         {
-          // TODO(clalancette): This can be simplified when RCLCPP_WARN_ONCE is available
-          static bool warned = false;
-          if (!warned)
-            {
-              RCLCPP_WARN(get_logger(), "VelodyneLaserScan: PointCloud2 fields in unexpected order. Using slower generic method.");
-              warned = true;
-            }
+          RCLCPP_WARN_ONCE(get_logger(), "VelodyneLaserScan: PointCloud2 fields in unexpected order. Using slower generic method.");
 
           if (offset_i >= 0)
             {

--- a/velodyne_laserscan/src/velodyne_laserscan.cpp
+++ b/velodyne_laserscan/src/velodyne_laserscan.cpp
@@ -223,7 +223,13 @@ void VelodyneLaserScan::recvCallback(const sensor_msgs::msg::PointCloud2::Shared
         }
       else
         {
-          RCLCPP_WARN(get_logger(), "VelodyneLaserScan: PointCloud2 fields in unexpected order. Using slower generic method.");
+          // TODO(clalancette): This can be simplified when RCLCPP_WARN_ONCE is available
+          static bool warned = false;
+          if (!warned)
+            {
+              RCLCPP_WARN(get_logger(), "VelodyneLaserScan: PointCloud2 fields in unexpected order. Using slower generic method.");
+              warned = true;
+            }
 
           if (offset_i >= 0)
             {

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -83,19 +83,17 @@ public:
   std::vector<LaserCorrection> laser_corrections;
   int num_lasers;
   bool initialized;
-  bool ros_info;
 
 public:
-  explicit Calibration(bool info = true)
+  Calibration()
   : distance_resolution_m(0.002f),
     num_lasers(0),
-    initialized(false),
-    ros_info(info) {}
-  explicit Calibration(
-    const std::string& calibration_file,
-    bool info = true)
-  : distance_resolution_m(0.002f),
-    ros_info(info)
+    initialized(false)
+  {
+  }
+
+  explicit Calibration(const std::string& calibration_file)
+  : distance_resolution_m(0.002f)
   {
     read(calibration_file);
   }

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -78,12 +78,11 @@ struct LaserCorrection
 class Calibration final
 {
 public:
+  explicit Calibration(const std::string& calibration_file);
+
   float distance_resolution_m;
   std::vector<LaserCorrection> laser_corrections;
   int num_lasers;
-
-public:
-  explicit Calibration(const std::string& calibration_file);
 };
 
 }  // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -79,7 +79,6 @@ class Calibration final
 {
 public:
   float distance_resolution_m;
-  std::map<int, LaserCorrection> laser_corrections_map;
   std::vector<LaserCorrection> laser_corrections;
   int num_lasers;
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -75,7 +75,7 @@ struct LaserCorrection
 };
 
 /** \brief Calibration information for the entire device. */
-class Calibration
+class Calibration final
 {
 public:
   float distance_resolution_m;
@@ -101,7 +101,6 @@ public:
   }
 
   void read(const std::string& calibration_file);
-  void write(const std::string& calibration_file);
 };
 
 }  // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -82,12 +82,9 @@ public:
   std::map<int, LaserCorrection> laser_corrections_map;
   std::vector<LaserCorrection> laser_corrections;
   int num_lasers;
-  bool initialized;
 
 public:
   explicit Calibration(const std::string& calibration_file);
-
-  void read(const std::string& calibration_file);
 };
 
 }  // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/calibration.h
@@ -85,18 +85,7 @@ public:
   bool initialized;
 
 public:
-  Calibration()
-  : distance_resolution_m(0.002f),
-    num_lasers(0),
-    initialized(false)
-  {
-  }
-
-  explicit Calibration(const std::string& calibration_file)
-  : distance_resolution_m(0.002f)
-  {
-    read(calibration_file);
-  }
+  explicit Calibration(const std::string& calibration_file);
 
   void read(const std::string& calibration_file);
 };

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -75,8 +75,8 @@ class Convert : public rclcpp::Node
       std::string target_frame;      ///< target frame
       std::string fixed_frame;       ///< fixed frame
       bool organize_cloud;           ///< enable/disable organized cloud structure
-      double max_range;              ///< maximum range to publish
       double min_range;              ///< minimum range to publish
+      double max_range;              ///< maximum range to publish
       int npackets;                  ///< number of packets to combine
       double view_direction;
       double view_width;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -76,8 +76,6 @@ class Convert : public rclcpp::Node
       std::string fixed_frame;       ///< fixed frame
       bool organize_cloud;           ///< enable/disable organized cloud structure
       int npackets;                  ///< number of packets to combine
-      double view_direction;
-      double view_width;
     }
     Config;
     Config config_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -67,7 +67,7 @@ class Convert : public rclcpp::Node
     rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr velodyne_scan_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
     tf2_ros::Buffer tf_buffer_;
-    std::shared_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
+    std::unique_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
 
     /// configuration parameters
     typedef struct

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -63,7 +63,7 @@ class Convert : public rclcpp::Node
   private:
     void processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scanMsg);
 
-    std::shared_ptr<velodyne_rawdata::RawData> data_;
+    std::unique_ptr<velodyne_rawdata::RawData> data_;
     rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr velodyne_scan_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
     tf2_ros::Buffer tf_buffer_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -75,8 +75,6 @@ class Convert : public rclcpp::Node
       std::string target_frame;      ///< target frame
       std::string fixed_frame;       ///< fixed frame
       bool organize_cloud;           ///< enable/disable organized cloud structure
-      double min_range;              ///< minimum range to publish
-      double max_range;              ///< maximum range to publish
       int npackets;                  ///< number of packets to combine
       double view_direction;
       double view_width;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -72,9 +72,6 @@ class Convert : public rclcpp::Node
     /// configuration parameters
     typedef struct
     {
-      std::string target_frame;      ///< target frame
-      std::string fixed_frame;       ///< fixed frame
-      bool organize_cloud;           ///< enable/disable organized cloud structure
       int npackets;                  ///< number of packets to combine
     }
     Config;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -77,7 +77,6 @@ class Convert : public rclcpp::Node
       bool organize_cloud;           ///< enable/disable organized cloud structure
       double max_range;              ///< maximum range to publish
       double min_range;              ///< minimum range to publish
-      uint16_t num_lasers;           ///< number of lasers
       int npackets;                  ///< number of packets to combine
       double view_direction;
       double view_width;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -54,34 +54,34 @@
 
 namespace velodyne_pointcloud
 {
-class Convert : public rclcpp::Node
+class Convert final : public rclcpp::Node
 {
-  public:
-    Convert();
-    ~Convert() {}
+public:
+  Convert();
+  ~Convert() {}
 
-  private:
-    void processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scanMsg);
+private:
+  void processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scanMsg);
 
-    std::unique_ptr<velodyne_rawdata::RawData> data_;
-    rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr velodyne_scan_;
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
-    tf2_ros::Buffer tf_buffer_;
-    std::unique_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
+  std::unique_ptr<velodyne_rawdata::RawData> data_;
+  rclcpp::Subscription<velodyne_msgs::msg::VelodyneScan>::SharedPtr velodyne_scan_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
+  tf2_ros::Buffer tf_buffer_;
+  std::unique_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
 
-    /// configuration parameters
-    typedef struct
-    {
-      int npackets;                  ///< number of packets to combine
-    }
-    Config;
-    Config config_;
+  /// configuration parameters
+  typedef struct
+  {
+    int npackets;                  ///< number of packets to combine
+  }
+  Config;
+  Config config_;
 
-    // diagnostics updater
-    //diagnostic_updater::Updater diagnostics_;
-    double diag_min_freq_;
-    double diag_max_freq_;
-    //std::shared_ptr<diagnostic_updater::TopicDiagnostic> diag_topic_;
+  // diagnostics updater
+  //diagnostic_updater::Updater diagnostics_;
+  double diag_min_freq_;
+  double diag_max_freq_;
+  //std::shared_ptr<diagnostic_updater::TopicDiagnostic> diag_topic_;
 };
 }  // namespace velodyne_pointcloud
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -55,10 +55,10 @@ namespace velodyne_rawdata
 class DataContainerBase
 {
 public:
-  DataContainerBase(const double min_range, const double max_range, const std::string& target_frame,
-                    const std::string& fixed_frame, const unsigned int init_width, const unsigned int init_height,
-                    const bool is_dense, const unsigned int scans_per_packet,
-                    tf2::BufferCore & buffer, int fields, ...)
+  explicit DataContainerBase(const double min_range, const double max_range, const std::string& target_frame,
+                             const std::string& fixed_frame, const unsigned int init_width, const unsigned int init_height,
+                             const bool is_dense, const unsigned int scans_per_packet,
+                             tf2::BufferCore & buffer, int fields, ...)
     : config_(min_range, max_range, target_frame, fixed_frame, init_width, init_height, is_dense, scans_per_packet)
     , tf_buffer_(buffer)
   {
@@ -80,7 +80,7 @@ public:
     cloud.row_step = cloud.width * cloud.point_step;
   }
 
-  struct Config
+  struct Config final
   {
     double min_range;          ///< minimum range to publish
     double max_range;          ///< maximum range to publish
@@ -92,8 +92,8 @@ public:
     unsigned int scans_per_packet;
     bool transform;  ///< enable / disable transform points
 
-    Config(double min_range, double max_range, std::string target_frame, std::string fixed_frame,
-           unsigned int init_width, unsigned int init_height, bool is_dense, unsigned int scans_per_packet)
+    explicit Config(double min_range, double max_range, std::string target_frame, std::string fixed_frame,
+                    unsigned int init_width, unsigned int init_height, bool is_dense, unsigned int scans_per_packet)
       : min_range(min_range)
       , max_range(max_range)
       , target_frame(target_frame)

--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -147,8 +147,8 @@ public:
     return cloud;
   }
 
-  void configure(const double min_range, const double max_range, const std::string fixed_frame,
-                 const std::string target_frame)
+  void configure(const double min_range, const double max_range, const std::string & fixed_frame,
+                 const std::string & target_frame)
   {
     config_.min_range = min_range;
     config_.max_range = max_range;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -55,11 +55,11 @@ namespace velodyne_rawdata
 class DataContainerBase
 {
 public:
-  DataContainerBase(const double max_range, const double min_range, const std::string& target_frame,
+  DataContainerBase(const double min_range, const double max_range, const std::string& target_frame,
                     const std::string& fixed_frame, const unsigned int init_width, const unsigned int init_height,
                     const bool is_dense, const unsigned int scans_per_packet,
                     tf2::BufferCore & buffer, int fields, ...)
-    : config_(max_range, min_range, target_frame, fixed_frame, init_width, init_height, is_dense, scans_per_packet)
+    : config_(min_range, max_range, target_frame, fixed_frame, init_width, init_height, is_dense, scans_per_packet)
     , tf_buffer_(buffer)
   {
     va_list vl;
@@ -82,8 +82,8 @@ public:
 
   struct Config
   {
-    double max_range;          ///< maximum range to publish
     double min_range;          ///< minimum range to publish
+    double max_range;          ///< maximum range to publish
     std::string target_frame;  ///< target frame to transform a point
     std::string fixed_frame;   ///< fixed frame used for transform
     unsigned int init_width;
@@ -92,10 +92,10 @@ public:
     unsigned int scans_per_packet;
     bool transform;  ///< enable / disable transform points
 
-    Config(double max_range, double min_range, std::string target_frame, std::string fixed_frame,
+    Config(double min_range, double max_range, std::string target_frame, std::string fixed_frame,
            unsigned int init_width, unsigned int init_height, bool is_dense, unsigned int scans_per_packet)
-      : max_range(max_range)
-      , min_range(min_range)
+      : min_range(min_range)
+      , max_range(max_range)
       , target_frame(target_frame)
       , fixed_frame(fixed_frame)
       , init_width(init_width)
@@ -147,11 +147,11 @@ public:
     return cloud;
   }
 
-  void configure(const double max_range, const double min_range, const std::string fixed_frame,
+  void configure(const double min_range, const double max_range, const std::string fixed_frame,
                  const std::string target_frame)
   {
-    config_.max_range = max_range;
     config_.min_range = min_range;
+    config_.max_range = max_range;
     config_.fixed_frame = fixed_frame;
     config_.target_frame = target_frame;
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIR.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIR.h
@@ -47,7 +47,7 @@ namespace velodyne_pointcloud
 class OrganizedCloudXYZIR : public velodyne_rawdata::DataContainerBase
 {
 public:
-  OrganizedCloudXYZIR(const double max_range, const double min_range, const std::string& target_frame,
+  OrganizedCloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
                       const std::string& fixed_frame, const unsigned int num_lasers, const unsigned int scans_per_block,
                       tf2::BufferCore & buffer);
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIR.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIR.h
@@ -44,19 +44,19 @@
 
 namespace velodyne_pointcloud
 {
-class OrganizedCloudXYZIR : public velodyne_rawdata::DataContainerBase
+class OrganizedCloudXYZIR final : public velodyne_rawdata::DataContainerBase
 {
 public:
-  OrganizedCloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
-                      const std::string& fixed_frame, const unsigned int num_lasers, const unsigned int scans_per_block,
-                      tf2::BufferCore & buffer);
+  explicit OrganizedCloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
+                               const std::string& fixed_frame, const unsigned int num_lasers, const unsigned int scans_per_block,
+                               tf2::BufferCore & buffer);
 
-  virtual void newLine();
+  void newLine() override;
 
-  virtual void setup(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan_msg);
+  void setup(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan_msg) override;
 
-  virtual void addPoint(float x, float y, float z, const uint16_t ring, const uint16_t azimuth, const float distance,
-                        const float intensity);
+  void addPoint(float x, float y, float z, const uint16_t ring, const uint16_t azimuth, const float distance,
+                const float intensity) override;
 
 private:
   sensor_msgs::PointCloud2Iterator<float> iter_x, iter_y, iter_z, iter_intensity;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIR.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIR.h
@@ -47,7 +47,7 @@ namespace velodyne_pointcloud
 class PointcloudXYZIR : public velodyne_rawdata::DataContainerBase
 {
 public:
-  PointcloudXYZIR(const double max_range, const double min_range, const std::string& target_frame,
+  PointcloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
                   const std::string& fixed_frame, const unsigned int scans_per_block,
                   tf2::BufferCore & buffer);
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIR.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIR.h
@@ -44,19 +44,20 @@
 
 namespace velodyne_pointcloud
 {
-class PointcloudXYZIR : public velodyne_rawdata::DataContainerBase
+class PointcloudXYZIR final : public velodyne_rawdata::DataContainerBase
 {
 public:
-  PointcloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
-                  const std::string& fixed_frame, const unsigned int scans_per_block,
-                  tf2::BufferCore & buffer);
+  explicit PointcloudXYZIR(const double min_range, const double max_range, const std::string& target_frame,
+                           const std::string& fixed_frame, const unsigned int scans_per_block,
+                           tf2::BufferCore & buffer);
 
-  virtual void newLine();
+  void newLine() override;
 
-  virtual void setup(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan_msg);
+  void setup(const velodyne_msgs::msg::VelodyneScan::SharedPtr scan_msg) override;
 
-  virtual void addPoint(float x, float y, float z, uint16_t ring, uint16_t azimuth, float distance, float intensity);
+  void addPoint(float x, float y, float z, uint16_t ring, uint16_t azimuth, float distance, float intensity) override;
 
+private:
   sensor_msgs::PointCloud2Iterator<float> iter_x, iter_y, iter_z, iter_intensity;
   sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring;
 };

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -147,8 +147,8 @@ private:
   /** configuration parameters */
   typedef struct
   {
-    double max_range;             ///< maximum range to publish
     double min_range;             ///< minimum range to publish
+    double max_range;             ///< maximum range to publish
     int min_angle;                ///< minimum angle to publish
     int max_angle;                ///< maximum angle to publish
   }

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -174,7 +174,7 @@ private:
   /**
    * Calibration file
    */
-  velodyne_pointcloud::Calibration calibration_;
+  std::unique_ptr<velodyne_pointcloud::Calibration> calibration_;
   float sin_rot_table_[ROTATION_MAX_UNITS];
   float cos_rot_table_[ROTATION_MAX_UNITS];
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -156,6 +156,8 @@ public:
 
   int scansPerPacket() const;
 
+  int numLasers() const;
+
 private:
   /** configuration parameters */
   typedef struct

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -150,19 +150,6 @@ public:
    */
   int setup(const std::string & calibration_file);
 
-  /** \brief Set up for data processing offline.
-   * Performs the same initialization as in setup, in the abscence of a ros::NodeHandle.
-   * this method is useful if unpacking data directly from bag files, without passing
-   * through a communication overhead.
-   *
-   * @param calibration_file path to the calibration file
-   * @param max_range_ cutoff for maximum range
-   * @param min_range_ cutoff for minimum range
-   * @returns 0 if successful;
-   *           errno value for failure
-   */
-  int setupOffline(const std::string & calibration_file, double max_range, double min_range);
-
   void unpack(const velodyne_msgs::msg::VelodynePacket &pkt, DataContainerBase& data);
 
   void setParameters(double min_range, double max_range, double view_direction, double view_width);

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -151,9 +151,6 @@ private:
     double min_range;             ///< minimum range to publish
     int min_angle;                ///< minimum angle to publish
     int max_angle;                ///< maximum angle to publish
-
-    double tmp_min_angle;
-    double tmp_max_angle;
   }
   Config;
   Config config_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -129,26 +129,11 @@ typedef struct raw_packet
 raw_packet_t;
 
 /** \brief Velodyne data conversion class */
-class RawData
+class RawData final
 {
 public:
-  RawData();
-  ~RawData()
-  {
-  }
-
-  /** \brief Set up for data processing.
-   *
-   *  Perform initializations needed before data processing can
-   *  begin:
-   *
-   *    - read device-specific angles calibration
-   *
-   *  @param private_nh private node handle for ROS parameters
-   *  @returns number of lasers if successful;
-   *           errno value for failure
-   */
-  int setup(const std::string & calibration_file);
+  explicit RawData(const std::string & calibration_file);
+  ~RawData();
 
   void unpack(const velodyne_msgs::msg::VelodynePacket &pkt, DataContainerBase& data);
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -148,7 +148,7 @@ public:
    *  @returns number of lasers if successful;
    *           errno value for failure
    */
-  int setup(const std::string & calibrationFile);
+  int setup(const std::string & calibration_file);
 
   /** \brief Set up for data processing offline.
    * Performs the same initialization as in setup, in the abscence of a ros::NodeHandle.
@@ -161,7 +161,7 @@ public:
    * @returns 0 if successful;
    *           errno value for failure
    */
-  int setupOffline(std::string calibration_file, double max_range_, double min_range_);
+  int setupOffline(const std::string & calibration_file, double max_range, double min_range);
 
   void unpack(const velodyne_msgs::msg::VelodynePacket &pkt, DataContainerBase& data);
 
@@ -173,7 +173,6 @@ private:
   /** configuration parameters */
   typedef struct
   {
-    std::string calibrationFile;  ///< calibration file name
     double max_range;             ///< maximum range to publish
     double min_range;             ///< minimum range to publish
     int min_angle;                ///< minimum angle to publish

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -81,8 +81,6 @@ private:
     std::string target_frame;  ///< target frame
     std::string fixed_frame;   ///< fixed frame
     bool organize_cloud;       ///< enable/disable organized cloud structure
-    double view_direction;
-    double view_width;
   }
   Config;
   Config config_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -90,7 +90,7 @@ private:
   Config;
   Config config_;
 
-  std::shared_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
+  std::unique_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
 
   // diagnostics updater
   //diagnostic_updater::Updater diagnostics_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -71,7 +71,6 @@ private:
 
   std::unique_ptr<velodyne_rawdata::RawData> data_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_ptr_;
   message_filters::Subscriber<velodyne_msgs::msg::VelodyneScan> velodyne_scan_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::MessageFilter<velodyne_msgs::msg::VelodyneScan> tf_filter_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -58,7 +58,7 @@
 
 namespace velodyne_pointcloud
 {
-class Transform : public rclcpp::Node
+class Transform final : public rclcpp::Node
 {
 public:
   Transform();

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -81,8 +81,8 @@ private:
     std::string target_frame;  ///< target frame
     std::string fixed_frame;   ///< fixed frame
     bool organize_cloud;       ///< enable/disable organized cloud structure
-    double max_range;          ///< maximum range to publish
     double min_range;          ///< minimum range to publish
+    double max_range;          ///< maximum range to publish
     double view_direction;
     double view_width;
   }

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -81,8 +81,6 @@ private:
     std::string target_frame;  ///< target frame
     std::string fixed_frame;   ///< fixed frame
     bool organize_cloud;       ///< enable/disable organized cloud structure
-    double min_range;          ///< minimum range to publish
-    double max_range;          ///< maximum range to publish
     double view_direction;
     double view_width;
   }

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -73,17 +73,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
   message_filters::Subscriber<velodyne_msgs::msg::VelodyneScan> velodyne_scan_;
   tf2_ros::Buffer tf_buffer_;
-  tf2_ros::MessageFilter<velodyne_msgs::msg::VelodyneScan> tf_filter_;
-
-  /// configuration parameters
-  typedef struct
-  {
-    std::string target_frame;  ///< target frame
-    std::string fixed_frame;   ///< fixed frame
-    bool organize_cloud;       ///< enable/disable organized cloud structure
-  }
-  Config;
-  Config config_;
+  std::unique_ptr<tf2_ros::MessageFilter<velodyne_msgs::msg::VelodyneScan>> tf_filter_;
 
   std::unique_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -84,7 +84,6 @@ private:
     bool organize_cloud;       ///< enable/disable organized cloud structure
     double max_range;          ///< maximum range to publish
     double min_range;          ///< minimum range to publish
-    uint16_t num_lasers;       ///< number of lasers
     double view_direction;
     double view_width;
   }

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -69,7 +69,7 @@ public:
 private:
   void processScan(const std::shared_ptr<const velodyne_msgs::msg::VelodyneScan> & scanMsg);
 
-  std::shared_ptr<velodyne_rawdata::RawData> data_;
+  std::unique_ptr<velodyne_rawdata::RawData> data_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr output_;
   std::shared_ptr<tf2_ros::TransformListener> tf_ptr_;
   message_filters::Subscriber<velodyne_msgs::msg::VelodyneScan> velodyne_scan_;

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -90,7 +90,7 @@ private:
   Config;
   Config config_;
 
-  std::shared_ptr<velodyne_rawdata::DataContainerBase> container_ptr;
+  std::shared_ptr<velodyne_rawdata::DataContainerBase> container_ptr_;
 
   // diagnostics updater
   //diagnostic_updater::Updater diagnostics_;

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -87,7 +87,7 @@ namespace velodyne_pointcloud
     if (success >= 0)
       {
         RCLCPP_DEBUG(get_logger(), "Calibration file loaded.");
-        config_.num_lasers = success;
+        config_.num_lasers = data_->numLasers();
       }
     else
       {

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -44,7 +44,7 @@ namespace velodyne_pointcloud
     min_range_range.from_value = 0.1;
     min_range_range.to_value = 10.0;
     min_range_desc.floating_point_range.push_back(min_range_range);
-    config_.min_range = this->declare_parameter("min_range", 0.9, min_range_desc);
+    double min_range = this->declare_parameter("min_range", 0.9, min_range_desc);
 
     rcl_interfaces::msg::ParameterDescriptor max_range_desc;
     max_range_desc.name = "max_range";
@@ -54,7 +54,7 @@ namespace velodyne_pointcloud
     max_range_range.from_value = 0.1;
     max_range_range.to_value = 200.0;
     max_range_desc.floating_point_range.push_back(max_range_range);
-    config_.max_range = this->declare_parameter("max_range", 130.0, max_range_desc);
+    double max_range = this->declare_parameter("max_range", 130.0, max_range_desc);
 
     rcl_interfaces::msg::ParameterDescriptor view_direction_desc;
     view_direction_desc.name = "view_direction";
@@ -88,14 +88,14 @@ namespace velodyne_pointcloud
     if (config_.organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.min_range, config_.max_range,
+          new OrganizedCloudXYZIR(min_range, max_range,
             config_.target_frame, config_.fixed_frame,
             data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
         container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.min_range, config_.max_range,
+          new PointcloudXYZIR(min_range, max_range,
             config_.target_frame, config_.fixed_frame,
             data_->scansPerPacket(), tf_buffer_));
       }
@@ -122,8 +122,8 @@ namespace velodyne_pointcloud
     //                                                         0.1, 10),
     //                                    TimeStampStatusParam()));
 
-    data_->setParameters(config_.min_range, config_.max_range, config_.view_direction, config_.view_width);
-    container_ptr_->configure(config_.min_range, config_.max_range, config_.fixed_frame, config_.target_frame);
+    data_->setParameters(min_range, max_range, config_.view_direction, config_.view_width);
+    container_ptr_->configure(min_range, max_range, config_.fixed_frame, config_.target_frame);
   }
 
   /** @brief Callback for raw scan messages. */

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -84,14 +84,13 @@ namespace velodyne_pointcloud
     RCLCPP_INFO(this->get_logger(), "correction angles: %s", calibrationFile.c_str());
 
     data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
-    config_.num_lasers = data_->numLasers();
 
     if (config_.organize_cloud)
       {
         container_ptr_ = std::shared_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
             config_.target_frame, config_.fixed_frame,
-            config_.num_lasers, data_->scansPerPacket(), tf_buffer_));
+            data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -31,7 +31,7 @@ namespace velodyne_pointcloud
 {
   /** @brief Constructor. */
   Convert::Convert() : rclcpp::Node("velodyne_convert_node"),
-    data_(new velodyne_rawdata::RawData()), tf_buffer_(this->get_clock())
+    tf_buffer_(this->get_clock())
   {
     // get path to angles.config file for this device
     std::string calibrationFile = this->declare_parameter("calibration", "");
@@ -83,16 +83,8 @@ namespace velodyne_pointcloud
 
     RCLCPP_INFO(this->get_logger(), "correction angles: %s", calibrationFile.c_str());
 
-    int success = data_->setup(calibrationFile);
-    if (success >= 0)
-      {
-        RCLCPP_DEBUG(get_logger(), "Calibration file loaded.");
-        config_.num_lasers = data_->numLasers();
-      }
-    else
-      {
-        RCLCPP_ERROR(get_logger(), "Could not load calibration file!");
-      }
+    data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
+    config_.num_lasers = data_->numLasers();
 
     if (config_.organize_cloud)
       {

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -87,14 +87,14 @@ namespace velodyne_pointcloud
 
     if (config_.organize_cloud)
       {
-        container_ptr_ = std::shared_ptr<OrganizedCloudXYZIR>(
+        container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
             config_.target_frame, config_.fixed_frame,
             data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
-        container_ptr_ = std::shared_ptr<PointcloudXYZIR>(
+        container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
           new PointcloudXYZIR(config_.max_range, config_.min_range,
             config_.target_frame, config_.fixed_frame,
             data_->scansPerPacket(), tf_buffer_));

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -64,7 +64,7 @@ namespace velodyne_pointcloud
     view_direction_range.from_value = -M_PI;
     view_direction_range.to_value = M_PI;
     view_direction_desc.floating_point_range.push_back(view_direction_range);
-    config_.view_direction = this->declare_parameter("view_direction", 0.0, view_direction_desc);
+    double view_direction = this->declare_parameter("view_direction", 0.0, view_direction_desc);
 
     rcl_interfaces::msg::ParameterDescriptor view_width_desc;
     view_width_desc.name = "view_width";
@@ -74,7 +74,7 @@ namespace velodyne_pointcloud
     view_width_range.from_value = 0.0;
     view_width_range.to_value = 2.0*M_PI;
     view_width_desc.floating_point_range.push_back(view_width_range);
-    config_.view_width = this->declare_parameter("view_width", 2.0*M_PI, view_width_desc);
+    double view_width = this->declare_parameter("view_width", 2.0*M_PI, view_width_desc);
 
     config_.organize_cloud = this->declare_parameter("organize_cloud", true);
 
@@ -122,7 +122,7 @@ namespace velodyne_pointcloud
     //                                                         0.1, 10),
     //                                    TimeStampStatusParam()));
 
-    data_->setParameters(min_range, max_range, config_.view_direction, config_.view_width);
+    data_->setParameters(min_range, max_range, view_direction, view_width);
     container_ptr_->configure(min_range, max_range, config_.fixed_frame, config_.target_frame);
   }
 

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -88,14 +88,14 @@ namespace velodyne_pointcloud
     if (config_.organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
+          new OrganizedCloudXYZIR(config_.min_range, config_.max_range,
             config_.target_frame, config_.fixed_frame,
             data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
         container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.max_range, config_.min_range,
+          new PointcloudXYZIR(config_.min_range, config_.max_range,
             config_.target_frame, config_.fixed_frame,
             data_->scansPerPacket(), tf_buffer_));
       }
@@ -123,7 +123,7 @@ namespace velodyne_pointcloud
     //                                    TimeStampStatusParam()));
 
     data_->setParameters(config_.min_range, config_.max_range, config_.view_direction, config_.view_width);
-    container_ptr_->configure(config_.max_range, config_.min_range, config_.fixed_frame, config_.target_frame);
+    container_ptr_->configure(config_.min_range, config_.max_range, config_.fixed_frame, config_.target_frame);
   }
 
   /** @brief Callback for raw scan messages. */

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -76,27 +76,27 @@ namespace velodyne_pointcloud
     view_width_desc.floating_point_range.push_back(view_width_range);
     double view_width = this->declare_parameter("view_width", 2.0*M_PI, view_width_desc);
 
-    config_.organize_cloud = this->declare_parameter("organize_cloud", true);
+    bool organize_cloud = this->declare_parameter("organize_cloud", true);
 
-    config_.target_frame = this->declare_parameter("target_frame", "");
-    config_.fixed_frame = this->declare_parameter("fixed_frame", "");
+    std::string target_frame = this->declare_parameter("target_frame", "");
+    std::string fixed_frame = this->declare_parameter("fixed_frame", "");
 
     RCLCPP_INFO(this->get_logger(), "correction angles: %s", calibrationFile.c_str());
 
     data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
 
-    if (config_.organize_cloud)
+    if (organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(min_range, max_range,
-            config_.target_frame, config_.fixed_frame,
+            target_frame, fixed_frame,
             data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
         container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
           new PointcloudXYZIR(min_range, max_range,
-            config_.target_frame, config_.fixed_frame,
+            target_frame, fixed_frame,
             data_->scansPerPacket(), tf_buffer_));
       }
 
@@ -123,7 +123,7 @@ namespace velodyne_pointcloud
     //                                    TimeStampStatusParam()));
 
     data_->setParameters(min_range, max_range, view_direction, view_width);
-    container_ptr_->configure(min_range, max_range, config_.fixed_frame, config_.target_frame);
+    container_ptr_->configure(min_range, max_range, target_frame, fixed_frame);
   }
 
   /** @brief Callback for raw scan messages. */

--- a/velodyne_pointcloud/src/conversions/organized_cloudXYZIR.cc
+++ b/velodyne_pointcloud/src/conversions/organized_cloudXYZIR.cc
@@ -12,12 +12,12 @@ namespace velodyne_pointcloud
 {
 
   OrganizedCloudXYZIR::OrganizedCloudXYZIR(
-      const double max_range, const double min_range,
+      const double min_range, const double max_range,
       const std::string& target_frame, const std::string& fixed_frame,
       const unsigned int num_lasers, const unsigned int scans_per_block,
       tf2::BufferCore & buffer)
     : DataContainerBase(
-        max_range, min_range, target_frame, fixed_frame,
+        min_range, max_range, target_frame, fixed_frame,
         num_lasers, 0, false, scans_per_block, buffer, 5,
         "x", 1, sensor_msgs::msg::PointField::FLOAT32,
         "y", 1, sensor_msgs::msg::PointField::FLOAT32,
@@ -49,7 +49,6 @@ namespace velodyne_pointcloud
     iter_ring = sensor_msgs::PointCloud2Iterator<uint16_t >(cloud, "ring");
   }
 
-
   void OrganizedCloudXYZIR::addPoint(float x, float y, float z,
       const uint16_t ring, const uint16_t /*azimuth*/, const float distance, const float intensity)
   {
@@ -61,7 +60,7 @@ namespace velodyne_pointcloud
      */
     if (pointInRange(distance))
       {
-        if(config_.transform)
+        if (config_.transform)
           {
             transformPoint(x, y, z);
           }
@@ -81,4 +80,4 @@ namespace velodyne_pointcloud
         *(iter_ring+ring) = ring;
       }
   }
-}
+}  // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/src/conversions/pointcloudXYZIR.cc
+++ b/velodyne_pointcloud/src/conversions/pointcloudXYZIR.cc
@@ -11,11 +11,11 @@ namespace velodyne_pointcloud
 {
 
   PointcloudXYZIR::PointcloudXYZIR(
-    const double max_range, const double min_range,
+    const double min_range, const double max_range,
     const std::string& target_frame, const std::string& fixed_frame,
     const unsigned int scans_per_block, tf2::BufferCore & tf_buffer)
     : DataContainerBase(
-        max_range, min_range, target_frame, fixed_frame,
+        min_range, max_range, target_frame, fixed_frame,
         0, 1, true, scans_per_block, tf_buffer, 5,
         "x", 1, sensor_msgs::msg::PointField::FLOAT32,
         "y", 1, sensor_msgs::msg::PointField::FLOAT32,
@@ -37,7 +37,8 @@ namespace velodyne_pointcloud
   }
 
   void PointcloudXYZIR::newLine()
-  {}
+  {
+  }
 
   void PointcloudXYZIR::addPoint(float x, float y, float z, uint16_t ring, uint16_t /*azimuth*/, float distance, float intensity)
   {
@@ -48,7 +49,7 @@ namespace velodyne_pointcloud
 
     // convert polar coordinates to Euclidean XYZ
 
-    if(config_.transform)
+    if (config_.transform)
       {
         transformPoint(x, y, z);
       }

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -90,8 +90,6 @@ namespace velodyne_pointcloud
 
     data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
 
-    tf_ptr_ = std::make_shared<tf2_ros::TransformListener>(tf_buffer_);
-
     if (config_.organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -92,7 +92,7 @@ namespace velodyne_pointcloud
     if (success >= 0)
       {
         RCLCPP_DEBUG(get_logger(), "Calibration file loaded.");
-        config_.num_lasers = success;
+        config_.num_lasers = data_->numLasers();
       }
     else
       {

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -50,7 +50,7 @@ namespace velodyne_pointcloud
     min_range_range.from_value = 0.1;
     min_range_range.to_value = 10.0;
     min_range_desc.floating_point_range.push_back(min_range_range);
-    config_.min_range = this->declare_parameter("min_range", 0.9, min_range_desc);
+    double min_range = this->declare_parameter("min_range", 0.9, min_range_desc);
 
     rcl_interfaces::msg::ParameterDescriptor max_range_desc;
     max_range_desc.name = "max_range";
@@ -60,7 +60,7 @@ namespace velodyne_pointcloud
     max_range_range.from_value = 0.1;
     max_range_range.to_value = 200.0;
     max_range_desc.floating_point_range.push_back(max_range_range);
-    config_.max_range = this->declare_parameter("max_range", 130.0, max_range_desc);
+    double max_range = this->declare_parameter("max_range", 130.0, max_range_desc);
 
     rcl_interfaces::msg::ParameterDescriptor view_direction_desc;
     view_direction_desc.name = "view_direction";
@@ -93,13 +93,13 @@ namespace velodyne_pointcloud
     if (config_.organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.min_range, config_.max_range, config_.target_frame, config_.fixed_frame,
+          new OrganizedCloudXYZIR(min_range, max_range, config_.target_frame, config_.fixed_frame,
                                   data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
         container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.min_range, config_.max_range,
+          new PointcloudXYZIR(min_range, max_range,
                               config_.target_frame, config_.fixed_frame,
                               data_->scansPerPacket(), tf_buffer_));
       }
@@ -123,8 +123,8 @@ namespace velodyne_pointcloud
     //                                                            0.1, 10),
     //                                       TimeStampStatusParam()));
 
-    data_->setParameters(config_.min_range, config_.max_range, config_.view_direction, config_.view_width);
-    container_ptr_->configure(config_.min_range, config_.max_range, config_.fixed_frame, config_.target_frame);
+    data_->setParameters(min_range, max_range, config_.view_direction, config_.view_width);
+    container_ptr_->configure(min_range, max_range, config_.fixed_frame, config_.target_frame);
   }
 
   /** @brief Callback for raw scan messages.

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -70,7 +70,7 @@ namespace velodyne_pointcloud
     view_direction_range.from_value = -M_PI;
     view_direction_range.to_value = M_PI;
     view_direction_desc.floating_point_range.push_back(view_direction_range);
-    config_.view_direction = this->declare_parameter("view_direction", 0.0, view_direction_desc);
+    double view_direction = this->declare_parameter("view_direction", 0.0, view_direction_desc);
 
     rcl_interfaces::msg::ParameterDescriptor view_width_desc;
     view_width_desc.name = "view_width";
@@ -80,7 +80,7 @@ namespace velodyne_pointcloud
     view_width_range.from_value = 0.0;
     view_width_range.to_value = 2.0*M_PI;
     view_width_desc.floating_point_range.push_back(view_width_range);
-    config_.view_width = this->declare_parameter("view_width", 2.0*M_PI, view_width_desc);
+    double view_width = this->declare_parameter("view_width", 2.0*M_PI, view_width_desc);
 
     config_.target_frame = this->declare_parameter("frame_id", "map");
     config_.fixed_frame = this->declare_parameter("fixed_frame", "odom");
@@ -123,7 +123,7 @@ namespace velodyne_pointcloud
     //                                                            0.1, 10),
     //                                       TimeStampStatusParam()));
 
-    data_->setParameters(min_range, max_range, config_.view_direction, config_.view_width);
+    data_->setParameters(min_range, max_range, view_direction, view_width);
     container_ptr_->configure(min_range, max_range, config_.fixed_frame, config_.target_frame);
   }
 

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -89,7 +89,6 @@ namespace velodyne_pointcloud
     RCLCPP_INFO(this->get_logger(), "correction angles: %s", calibrationFile.c_str());
 
     data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
-    config_.num_lasers = data_->numLasers();
 
     tf_ptr_ = std::make_shared<tf2_ros::TransformListener>(tf_buffer_);
 
@@ -97,7 +96,7 @@ namespace velodyne_pointcloud
       {
         container_ptr = std::shared_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
-                                  config_.num_lasers, data_->scansPerPacket(), tf_buffer_));
+                                  data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -94,13 +94,13 @@ namespace velodyne_pointcloud
 
     if (config_.organize_cloud)
       {
-        container_ptr_ = std::shared_ptr<OrganizedCloudXYZIR>(
+        container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
                                   data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
-        container_ptr_ = std::shared_ptr<PointcloudXYZIR>(
+        container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
           new PointcloudXYZIR(config_.max_range, config_.min_range,
                               config_.target_frame, config_.fixed_frame,
                               data_->scansPerPacket(), tf_buffer_));

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -38,7 +38,7 @@ namespace velodyne_pointcloud
   /** @brief Constructor. */
   Transform::Transform() :
     rclcpp::Node("velodyne_transform_node"),
-    data_(new velodyne_rawdata::RawData()), velodyne_scan_(this, "velodyne_packets"), tf_buffer_(this->get_clock()), tf_filter_(velodyne_scan_, tf_buffer_, config_.target_frame, 10, 0)
+    velodyne_scan_(this, "velodyne_packets"), tf_buffer_(this->get_clock()), tf_filter_(velodyne_scan_, tf_buffer_, config_.target_frame, 10, 0)
   {
     std::string calibrationFile = this->declare_parameter("calibration", "");
 
@@ -88,16 +88,8 @@ namespace velodyne_pointcloud
 
     RCLCPP_INFO(this->get_logger(), "correction angles: %s", calibrationFile.c_str());
 
-    int success = data_->setup(calibrationFile);
-    if (success >= 0)
-      {
-        RCLCPP_DEBUG(get_logger(), "Calibration file loaded.");
-        config_.num_lasers = data_->numLasers();
-      }
-    else
-      {
-        RCLCPP_ERROR(get_logger(), "Could not load calibration file!");
-      }
+    data_ = std::make_unique<velodyne_rawdata::RawData>(calibrationFile);
+    config_.num_lasers = data_->numLasers();
 
     tf_ptr_ = std::make_shared<tf2_ros::TransformListener>(tf_buffer_);
 

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -94,13 +94,13 @@ namespace velodyne_pointcloud
 
     if (config_.organize_cloud)
       {
-        container_ptr = std::shared_ptr<OrganizedCloudXYZIR>(
+        container_ptr_ = std::shared_ptr<OrganizedCloudXYZIR>(
           new OrganizedCloudXYZIR(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
                                   data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
-        container_ptr = std::shared_ptr<PointcloudXYZIR>(
+        container_ptr_ = std::shared_ptr<PointcloudXYZIR>(
           new PointcloudXYZIR(config_.max_range, config_.min_range,
                               config_.target_frame, config_.fixed_frame,
                               data_->scansPerPacket(), tf_buffer_));
@@ -126,7 +126,7 @@ namespace velodyne_pointcloud
     //                                       TimeStampStatusParam()));
 
     data_->setParameters(config_.min_range, config_.max_range, config_.view_direction, config_.view_width);
-    container_ptr->configure(config_.max_range, config_.min_range, config_.fixed_frame, config_.target_frame);
+    container_ptr_->configure(config_.max_range, config_.min_range, config_.fixed_frame, config_.target_frame);
   }
 
   /** @brief Callback for raw scan messages.
@@ -143,16 +143,16 @@ namespace velodyne_pointcloud
       }
 
     velodyne_msgs::msg::VelodyneScan* raw = const_cast<velodyne_msgs::msg::VelodyneScan*>(scanMsg.get());
-    container_ptr->setup(std::shared_ptr<velodyne_msgs::msg::VelodyneScan>(raw));
+    container_ptr_->setup(std::shared_ptr<velodyne_msgs::msg::VelodyneScan>(raw));
 
     // process each packet provided by the driver
     for (size_t i = 0; i < scanMsg->packets.size(); ++i)
       {
-        data_->unpack(scanMsg->packets[i], *container_ptr);
+        data_->unpack(scanMsg->packets[i], *container_ptr_);
       }
 
     // publish the accumulated cloud message
-    output_->publish(container_ptr->finishCloud());
+    output_->publish(container_ptr_->finishCloud());
     //diag_topic_->tick(scanMsg->header.stamp);
     //diagnostics_.update();
   }

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -93,13 +93,13 @@ namespace velodyne_pointcloud
     if (config_.organize_cloud)
       {
         container_ptr_ = std::unique_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
+          new OrganizedCloudXYZIR(config_.min_range, config_.max_range, config_.target_frame, config_.fixed_frame,
                                   data_->numLasers(), data_->scansPerPacket(), tf_buffer_));
       }
     else
       {
         container_ptr_ = std::unique_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.max_range, config_.min_range,
+          new PointcloudXYZIR(config_.min_range, config_.max_range,
                               config_.target_frame, config_.fixed_frame,
                               data_->scansPerPacket(), tf_buffer_));
       }
@@ -124,7 +124,7 @@ namespace velodyne_pointcloud
     //                                       TimeStampStatusParam()));
 
     data_->setParameters(config_.min_range, config_.max_range, config_.view_direction, config_.view_width);
-    container_ptr_->configure(config_.max_range, config_.min_range, config_.fixed_frame, config_.target_frame);
+    container_ptr_->configure(config_.min_range, config_.max_range, config_.fixed_frame, config_.target_frame);
   }
 
   /** @brief Callback for raw scan messages.

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -57,6 +57,12 @@ namespace velodyne_pointcloud
   const std::string FOCAL_DISTANCE = "focal_distance";
   const std::string FOCAL_SLOPE = "focal_slope";
 
+  Calibration::Calibration(const std::string& calibration_file)
+    : distance_resolution_m(0.002f)
+  {
+    read(calibration_file);
+  }
+
   /** Read calibration for a single laser. */
   void operator >> (const YAML::Node& node,
                     std::pair<int, LaserCorrection>& correction)

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -167,7 +167,6 @@ namespace velodyne_pointcloud
             calibration.laser_corrections.resize(index+1);
           }
         calibration.laser_corrections[index] = (correction.second);
-        calibration.laser_corrections_map.insert(correction);
       }
 
     // For each laser ring, find the next-smallest vertical angle.

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -205,59 +205,6 @@ namespace velodyne_pointcloud
       }
   }
 
-  YAML::Emitter& operator << (YAML::Emitter& out,
-                              const std::pair<int, LaserCorrection> correction)
-  {
-    out << YAML::BeginMap;
-    out << YAML::Key << LASER_ID << YAML::Value << correction.first;
-    out << YAML::Key << ROT_CORRECTION <<
-      YAML::Value << correction.second.rot_correction;
-    out << YAML::Key << VERT_CORRECTION <<
-      YAML::Value << correction.second.vert_correction;
-    out << YAML::Key << DIST_CORRECTION <<
-      YAML::Value << correction.second.dist_correction;
-    out << YAML::Key << TWO_PT_CORRECTION_AVAILABLE <<
-      YAML::Value << correction.second.two_pt_correction_available;
-    out << YAML::Key << DIST_CORRECTION_X <<
-      YAML::Value << correction.second.dist_correction_x;
-    out << YAML::Key << DIST_CORRECTION_Y <<
-      YAML::Value << correction.second.dist_correction_y;
-    out << YAML::Key << VERT_OFFSET_CORRECTION <<
-      YAML::Value << correction.second.vert_offset_correction;
-    out << YAML::Key << HORIZ_OFFSET_CORRECTION <<
-      YAML::Value << correction.second.horiz_offset_correction;
-    out << YAML::Key << MAX_INTENSITY <<
-      YAML::Value << correction.second.max_intensity;
-    out << YAML::Key << MIN_INTENSITY <<
-      YAML::Value << correction.second.min_intensity;
-    out << YAML::Key << FOCAL_DISTANCE <<
-      YAML::Value << correction.second.focal_distance;
-    out << YAML::Key << FOCAL_SLOPE <<
-      YAML::Value << correction.second.focal_slope;
-    out << YAML::EndMap;
-    return out;
-  }
-
-  YAML::Emitter& operator <<
-  (YAML::Emitter& out, const Calibration& calibration)
-  {
-    out << YAML::BeginMap;
-    out << YAML::Key << NUM_LASERS <<
-      YAML::Value << calibration.laser_corrections.size();
-    out << YAML::Key << DISTANCE_RESOLUTION <<
-      YAML::Value << calibration.distance_resolution_m;
-    out << YAML::Key << LASERS << YAML::Value << YAML::BeginSeq;
-    for (std::map<int, LaserCorrection>::const_iterator
-           it = calibration.laser_corrections_map.begin();
-         it != calibration.laser_corrections_map.end(); it++)
-      {
-        out << *it;
-      }
-    out << YAML::EndSeq;
-    out << YAML::EndMap;
-    return out;
-  }
-
   void Calibration::read(const std::string& calibration_file)
   {
     std::ifstream fin(calibration_file.c_str());
@@ -285,15 +232,6 @@ namespace velodyne_pointcloud
         initialized = false;
       }
     fin.close();
-  }
-
-  void Calibration::write(const std::string& calibration_file)
-  {
-    std::ofstream fout(calibration_file.c_str());
-    YAML::Emitter out;
-    out << *this;
-    fout << out.c_str();
-    fout.close();
   }
 
 }  // namespace velodyne_pointcloud

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -196,11 +196,6 @@ namespace velodyne_pointcloud
             // store this ring number with its corresponding laser number
             calibration.laser_corrections[next_index].laser_ring = ring;
             next_angle = min_seen;
-            if (calibration.ros_info)
-              {
-                //ROS_INFO("laser_ring[%2u] = %2u, angle = %+.6f",
-                //         next_index, ring, next_angle);
-              }
           }
       }
   }

--- a/velodyne_pointcloud/src/lib/calibration.cc
+++ b/velodyne_pointcloud/src/lib/calibration.cc
@@ -57,12 +57,6 @@ namespace velodyne_pointcloud
   const std::string FOCAL_DISTANCE = "focal_distance";
   const std::string FOCAL_SLOPE = "focal_slope";
 
-  Calibration::Calibration(const std::string& calibration_file)
-    : distance_resolution_m(0.002f)
-  {
-    read(calibration_file);
-  }
-
   /** Read calibration for a single laser. */
   void operator >> (const YAML::Node& node,
                     std::pair<int, LaserCorrection>& correction)
@@ -206,15 +200,14 @@ namespace velodyne_pointcloud
       }
   }
 
-  void Calibration::read(const std::string& calibration_file)
+  Calibration::Calibration(const std::string& calibration_file)
+    : distance_resolution_m(0.002f)
   {
     std::ifstream fin(calibration_file.c_str());
     if (!fin.is_open())
       {
-        initialized = false;
-        return;
+        throw std::runtime_error("Failed to open calibration file");
       }
-    initialized = true;
     try
       {
         YAML::Node doc;
@@ -229,8 +222,8 @@ namespace velodyne_pointcloud
       }
     catch (YAML::Exception &e)
       {
-        std::cerr << "YAML Exception: " << e.what() << std::endl;
-        initialized = false;
+        fin.close();
+        throw std::runtime_error("YAML Exception: " + std::string(e.what()));
       }
     fin.close();
   }

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -91,15 +91,13 @@ namespace velodyne_rawdata
   }
 
   /** Set up for on-line operation. */
-  int RawData::setup(const std::string & calibrationFile)
+  int RawData::setup(const std::string & calibration_file)
   {
-    config_.calibrationFile = calibrationFile;
-
-    calibration_.read(config_.calibrationFile);
+    calibration_.read(calibration_file);
     if (!calibration_.initialized)
       {
         //RCLCPP_ERROR(this->get_logger(), "Unable to open calibration file: %s",
-        //             config_.calibrationFile);
+        //             calibration_file);
         return -1;
       }
 
@@ -117,17 +115,15 @@ namespace velodyne_rawdata
 
 
   /** Set up for offline operation */
-  int RawData::setupOffline(std::string calibration_file, double max_range_, double min_range_)
+  int RawData::setupOffline(const std::string & calibration_file, double max_range, double min_range)
   {
-    config_.max_range = max_range_;
-    config_.min_range = min_range_;
+    config_.max_range = max_range;
+    config_.min_range = min_range;
     //RCLCPP_INFO(get_logger(), "data ranges to publish: [%f, %f]", config_.min_range, config_.max_range);
-
-    config_.calibrationFile = calibration_file;
 
     //RCLCPP_INFO(get_logger(), "correction angles: %s", config_.calibrationFile.c_str());
 
-    calibration_.read(config_.calibrationFile);
+    calibration_.read(calibration_file);
     if (!calibration_.initialized)
       {
         //RCLCPP_ERROR(get_logger(), "Unable to open calibration file: %s", config_.calibrationFile);

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -94,12 +94,6 @@ namespace velodyne_rawdata
   int RawData::setup(const std::string & calibration_file)
   {
     calibration_ = std::make_unique<velodyne_pointcloud::Calibration>(calibration_file);
-    if (!calibration_->initialized)
-      {
-        //RCLCPP_ERROR(this->get_logger(), "Unable to open calibration file: %s",
-        //             calibration_file);
-        return -1;
-      }
 
     //RCLCPP_INFO(this->get_logger(), "Number of lasers: %d.",  calibration_->num_lasers);
 

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -90,6 +90,11 @@ namespace velodyne_rawdata
       }
   }
 
+  int RawData::numLasers() const
+  {
+    return calibration_->num_lasers;
+  }
+
   /** Set up for on-line operation. */
   int RawData::setup(const std::string & calibration_file)
   {
@@ -104,7 +109,7 @@ namespace velodyne_rawdata
         cos_rot_table_[rot_index] = ::cosf(rotation);
         sin_rot_table_[rot_index] = ::sinf(rotation);
       }
-    return calibration_->num_lasers;
+    return 0;
   }
 
   /** @brief convert raw packet to point cloud

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -73,17 +73,17 @@ namespace velodyne_rawdata
     config_.max_range = max_range;
 
     // converting angle parameters into the velodyne reference (rad)
-    config_.tmp_min_angle = view_direction + view_width/2;
-    config_.tmp_max_angle = view_direction - view_width/2;
+    double tmp_min_angle = view_direction + view_width/2;
+    double tmp_max_angle = view_direction - view_width/2;
 
     // computing positive modulo to keep theses angles into [0;2*M_PI]
-    config_.tmp_min_angle = ::fmod(::fmod(config_.tmp_min_angle, 2*M_PI) + 2*M_PI, 2*M_PI);
-    config_.tmp_max_angle = ::fmod(::fmod(config_.tmp_max_angle, 2*M_PI) + 2*M_PI, 2*M_PI);
+    tmp_min_angle = ::fmod(::fmod(tmp_min_angle, 2*M_PI) + 2*M_PI, 2*M_PI);
+    tmp_max_angle = ::fmod(::fmod(tmp_max_angle, 2*M_PI) + 2*M_PI, 2*M_PI);
 
     // converting into the hardware velodyne ref (negative yaml and degrees)
     // adding 0.5 performs a centered double to int conversion
-    config_.min_angle = 100 * (2*M_PI - config_.tmp_min_angle) * 180 / M_PI + 0.5;
-    config_.max_angle = 100 * (2*M_PI - config_.tmp_max_angle) * 180 / M_PI + 0.5;
+    config_.min_angle = 100 * (2*M_PI - tmp_min_angle) * 180 / M_PI + 0.5;
+    config_.max_angle = 100 * (2*M_PI - tmp_max_angle) * 180 / M_PI + 0.5;
     if (config_.min_angle == config_.max_angle)
       {
         // avoid returning empty cloud if min_angle = max_angle

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -113,34 +113,6 @@ namespace velodyne_rawdata
     return calibration_.num_lasers;
   }
 
-
-  /** Set up for offline operation */
-  int RawData::setupOffline(const std::string & calibration_file, double max_range, double min_range)
-  {
-    config_.max_range = max_range;
-    config_.min_range = min_range;
-    //RCLCPP_INFO(get_logger(), "data ranges to publish: [%f, %f]", config_.min_range, config_.max_range);
-
-    //RCLCPP_INFO(get_logger(), "correction angles: %s", config_.calibrationFile.c_str());
-
-    calibration_.read(calibration_file);
-    if (!calibration_.initialized)
-      {
-        //RCLCPP_ERROR(get_logger(), "Unable to open calibration file: %s", config_.calibrationFile);
-        return -1;
-      }
-
-    // Set up cached values for sin and cos of all the possible headings
-    for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index)
-      {
-        float rotation = angles::from_degrees(ROTATION_RESOLUTION * rot_index);
-        cos_rot_table_[rot_index] = ::cosf(rotation);
-        sin_rot_table_[rot_index] = ::sinf(rotation);
-      }
-    return 0;
-  }
-
-
   /** @brief convert raw packet to point cloud
    *
    *  @param pkt raw packet to unpack


### PR DESCRIPTION
This is a somewhat large and subjective PR, but the main goal here is to reduce the amount of duplicate storage of configuration parameters in the classes that make up the velodyne_pointcloud code.  The main benefits of doing so are:

1.  Helps with readability
1.  Makes it easier to implement on-the-fly parameter changes (which will come in a follow-on PR)
1.  Reduces memory footprint slightly

There is also a bunch of cleanup of code in this PR, along with the removal of some unused functions.  My suggestion for reviewing this is commit-by-commit, since each commit is fairly small and does one logical thing.  @JWhitleyAStuff if you'd prefer a couple of smaller PRs, I can do that too; just let me know.

Thanks!