### PR TITLE
when device poll timeouts, do not stop node

### DIFF
--- a/velodyne_driver/src/driver/velodyne_node.cc
+++ b/velodyne_driver/src/driver/velodyne_node.cc
@@ -48,8 +48,13 @@ int main(int argc, char** argv)
   velodyne_driver::VelodyneDriver dvr(node, private_nh);
 
   // loop until shut down or end of file
-  while(ros::ok() && dvr.poll())
+  while(ros::ok())
     {
+      // poll device until end of file
+      bool polled_ = dvr.poll();
+      if (!polled_)
+        ROS_ERROR_THROTTLE(1.0, "Velodyne - Failed to poll device.");
+
       ros::spinOnce();
     }
 


### PR DESCRIPTION
As a follow-up to #213 and the implementation in #216, I added support for not exiting the driver on poll timeouts to the node as well. I assume there is no specific reason why the node should behave differently than the nodelet here.