### PR TITLE
Adding more precise scan separation feature

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/convert.h
@@ -88,6 +88,12 @@ class Convert
     Config config_;
     bool first_rcfg_call;
 
+    // Additional parameters for checking azimuth differences between consecutive data blocks
+    velodyne_msgs::VelodyneScanPtr adjusted_vel_msg_ptr {new velodyne_msgs::VelodyneScan};
+    int last_azimuth_;
+    int current_azimuth_diff_;
+    int prev_azimuth_diff_;
+
   // diagnostics updater
   diagnostic_updater::Updater diagnostics_;
   double diag_min_freq_;

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -56,6 +56,10 @@ namespace velodyne_pointcloud
     current_azimuth_diff_ = -1;
     prev_azimuth_diff_ = -1;
 
+    container_ptr_->last_azimuth_corrected = -1;
+    container_ptr_->current_corrected_azimuth_diff = -1;
+    container_ptr_->prev_corrected_azimuth_diff = -1;
+
     // advertise output point cloud (before subscribing to input data)
     output_ =
       node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -51,6 +51,10 @@ namespace velodyne_pointcloud
               data_->scansPerPacket()));
     }
 
+    // Initilize all parameters used for data block azimuth difference calculation
+    last_azimuth_ = -1;
+    current_azimuth_diff_ = -1;
+    prev_azimuth_diff_ = -1;
 
     // advertise output point cloud (before subscribing to input data)
     output_ =
@@ -131,11 +135,56 @@ namespace velodyne_pointcloud
     // process each packet provided by the driver
     for (size_t i = 0; i < scanMsg->packets.size(); ++i)
     {
-      data_->unpack(scanMsg->packets[i], *container_ptr_);
+        velodyne_msgs::VelodynePacket tmp_packet = scanMsg->packets[i];
+
+        // Extract base rotation of first block in packet
+        std::size_t azimuth_data_pos = 100*0+2;
+        int azimuth = *( (u_int16_t*) (&tmp_packet.data[azimuth_data_pos]));
+
+        //if first packet in scan, there is no "valid" last_azimuth_
+        if (last_azimuth_ == -1)
+        {
+            last_azimuth_ = azimuth;
+            continue;
+        }
+        if (current_azimuth_diff_ == -1)
+        {
+            current_azimuth_diff_ = azimuth - last_azimuth_;
+            continue;
+        }
+        if (prev_azimuth_diff_ == -1)
+        {
+            prev_azimuth_diff_ = current_azimuth_diff_;
+            continue;
+        }
+        current_azimuth_diff_ = azimuth - last_azimuth_;
+
+        adjusted_vel_msg_ptr->packets.push_back(tmp_packet);
+
+        if ((current_azimuth_diff_ < 0) && (prev_azimuth_diff_ >= 0))
+        {
+            // Current and previous azimuth differences have the same sign indicating the current packet was taken at 0 deg
+            adjusted_vel_msg_ptr->header.stamp = tmp_packet.stamp;
+
+            // allocate a point cloud with same time and frame ID as raw data
+            container_ptr_->setup(adjusted_vel_msg_ptr);
+            container_ptr_->offloadResidualPoint();
+
+            // process each packet
+            for (size_t j = 0; j < adjusted_vel_msg_ptr->packets.size(); ++j)
+            {
+              data_->unpack(adjusted_vel_msg_ptr->packets[j], *container_ptr_);
+            }
+
+            // Clear all the converted packets
+            adjusted_vel_msg_ptr->packets.clear();
+        }
+        last_azimuth_ = azimuth;
+        prev_azimuth_diff_ = current_azimuth_diff_;
     }
 
     // publish the accumulated cloud message
-    diag_topic_->tick(scanMsg->header.stamp);
+    diag_topic_->tick(adjusted_vel_msg_ptr->header.stamp);
     diagnostics_.update();
     output_.publish(container_ptr_->finishCloud());
   }


### PR DESCRIPTION
Hi all.
I'm working on some mapping projects at MapIV, Inc. (TierIV's subsidiary company). During the projects, I found a way to improve the current Velodyne ROS driver, so my team and I think it might be worth sharing here. If I'm missing something or I got something wrong, I would be more than happy to hear from you all :)

It seems to me that the current implementation only allows creating one full scan from a set of complete packets, say 76 packets/scan or 77 packets/scan. But sometimes, one full scan is actually equivalent to some complete packets and a fraction of it, for example, 76.3 packets/scan. In this case, rounding the number of packets/scan up or down will result in redundant points or missing points in a scan, respectively (see the figures below).

**Redundant points**
![imperfect2](https://user-images.githubusercontent.com/23651560/63761509-423b3100-c8fc-11e9-81b6-5229c409ea45.png)
**Missing points**
![imperfect1](https://user-images.githubusercontent.com/23651560/63761485-3485ab80-c8fc-11e9-944f-19637da54fec.png)

So, what I did was basically modifying the driver to separate each scan more precisely. The separation mainly relies on azimuth data each point was taken (estimated using the azimuth of the packet and the firing timing). If the azimuth differences of three consecutive points have different signs, it is assumed that the last point belongs to a new scan. Therefore, it is stored in a residual point cloud waiting to be merged to the next scan. The code for this can be found [here](https://github.com/ros-drivers/velodyne/compare/master...MapIV:feature/precise_scan_separation?expand=1#diff-70aae7a710580a1d71ad71c8e11bedf6R503-R522).

Also, it is important to ensure that the number of packets in velodyne_msgs::VelodyneScan is more than the final exact packets/scan. For example, if the final number of packets/scan is 76.3, velodyne_msgs::VelodyneScan needs to contain 77 packets in total. The code for this part can be found [here](https://github.com/ros-drivers/velodyne/compare/master...MapIV:feature/precise_scan_separation?expand=1#diff-f19c2683e7974bb6c1e3e67865dccab2R142-R187).

Lastly, I also use the estimated timestamp of the last point in a scan as the scan timestamp instead of using the last packet timestamp as in the current implementation or the first packet as mentioned [here](https://github.com/ros-drivers/velodyne/issues/280).

**Video comparing current driver and the modified driver**
[![IMAGE ALT TEXT](http://img.youtube.com/vi/YOCg2783kN4/0.jpg)](http://www.youtube.com/watch?v=YOCg2783kN4 "Modified Velodyne ROS driver")

**Limitations**
- Only works with VLP16 and VLP16-Hires
- Only works with unsorted Point Cloud
- Might be slower than the current implementation as it includes more processing

**Related discussions**
- https://github.com/ros-drivers/velodyne/issues/280
- https://github.com/ros-drivers/velodyne/issues/242
- https://github.com/ros-drivers/velodyne/issues/231
