### PR TITLE
Check for intra-process subscribers

### DIFF
--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -130,9 +130,10 @@ namespace velodyne_pointcloud
   /** @brief Callback for raw scan messages. */
   void Convert::processScan(const velodyne_msgs::msg::VelodyneScan::SharedPtr scanMsg)
   {
-    if (output_->get_subscription_count() == 0)   // no one listening?
+    if (output_->get_subscription_count() == 0 && output_->get_intra_process_subscription_count() == 0)   // no one listening?
+    {
       return;                                     // avoid much work
-
+    }
     // allocate a point cloud with same time and frame ID as raw data
     container_ptr_->setup(scanMsg);
 

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -137,7 +137,7 @@ namespace velodyne_pointcloud
   void
     Transform::processScan(const std::shared_ptr<const velodyne_msgs::msg::VelodyneScan> & scanMsg)
   {
-    if (output_->get_subscription_count() == 0)    // no one listening?
+    if (output_->get_subscription_count() == 0 && output_->get_intra_process_subscription_count() == 0)    // no one listening?
       {
         return;                                     // avoid much work
       }


### PR DESCRIPTION
When running as a composed node in a container, the usual `get_subscription_count()` method may return 0; it's necessary to also check `get_intra_process_subscription_count()`.

Distribution Statement A; OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>