### PR TITLE
Fix ring retrieval from float pointcloud iterator.

### DIFF
--- a/velodyne_laserscan/src/velodyne_laserscan.cpp
+++ b/velodyne_laserscan/src/velodyne_laserscan.cpp
@@ -179,9 +179,7 @@ void VelodyneLaserScan::recvCallback(const sensor_msgs::msg::PointCloud2::Shared
       scan->intensities.resize(kSize);
 
       for (sensor_msgs::PointCloud2ConstIterator<float> it(*msg, "x"); it != it.end(); ++it) {
-        const uint16_t r =
-          (static_cast<const uint16_t>(it[5]) << 8) |
-          static_cast<const uint16_t>(it[6]);
+        const uint16_t r = *(reinterpret_cast<const uint16_t *>(&it[5]));
 
         if (r == ring) {
           const float x = it[0];  // x

--- a/velodyne_laserscan/src/velodyne_laserscan.cpp
+++ b/velodyne_laserscan/src/velodyne_laserscan.cpp
@@ -179,6 +179,11 @@ void VelodyneLaserScan::recvCallback(const sensor_msgs::msg::PointCloud2::Shared
       scan->intensities.resize(kSize);
 
       for (sensor_msgs::PointCloud2ConstIterator<float> it(*msg, "x"); it != it.end(); ++it) {
+        // Field "ring" is of UINT16 type, 2 bytes long. But this loop's iterator assumes FLOAT32
+        // type fields, 4 bytes long. Thus, de-referencing it (even) at the right offset will
+        // only yield "ring" field bytes, plus 2 bytes right after it, interpreted as a float
+        // value. We can, however, re-interpret that float value binary representation as that
+        // of an unsigned integer, 16 bit long.
         const uint16_t r = *(reinterpret_cast<const uint16_t *>(&it[5]));
 
         if (r == ring) {


### PR DESCRIPTION
Precisely what the title says. I stumbled upon this while trying to use the `velodyne_laserscan` node along with `velodyne` Gazebo plugins. `r` would always be `0`. I *believe* (do correct me if I'm wrong) that this is what the original author had in mind. 

Tagging @clalancette for awareness.