### PR TITLE
Increase VLP32-C max range

### DIFF
--- a/velodyne_pointcloud/launch/VLP-32C_points.launch
+++ b/velodyne_pointcloud/launch/VLP-32C_points.launch
@@ -8,7 +8,7 @@
   <arg name="device_ip" default="" />
   <arg name="frame_id" default="velodyne" />
   <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
-  <arg name="max_range" default="130.0" />
+  <arg name="max_range" default="200.0" />
   <arg name="min_range" default="0.4" />
   <arg name="pcap" default="" />
   <arg name="port" default="2368" />


### PR DESCRIPTION
This model supports ranges of 200m, not 130 as is the default

Completes: #315 