### PR TITLE
Correct resize to prevent SIGSEGV on HDL64 S3.

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
@@ -126,7 +126,7 @@ public:
     cloud.row_step = cloud.width * cloud.point_step;
     int data_size = scan_msg->packets.size() * config_.scans_per_packet * cloud.point_step;
     // additional space is required for HDL64 S3
-    if(!cloud.is_dense && cloud.width == 64) {
+    if (!cloud.is_dense && cloud.width == 64) {
       data_size = scan_msg->packets.size() * config_.scans_per_packet * cloud.point_step * 2;
     }
     cloud.data.resize(data_size);

--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
@@ -124,7 +124,12 @@ public:
     cloud.height = config_.init_height;
     cloud.is_dense = static_cast<uint8_t>(config_.is_dense);
     cloud.row_step = cloud.width * cloud.point_step;
-    cloud.data.resize(scan_msg->packets.size() * config_.scans_per_packet * cloud.point_step);
+    int data_size = scan_msg->packets.size() * config_.scans_per_packet * cloud.point_step;
+    // additional space is required for HDL64 S3
+    if(!cloud.is_dense && cloud.width == 64) {
+      data_size = scan_msg->packets.size() * config_.scans_per_packet * cloud.point_step * 2;
+    }
+    cloud.data.resize(data_size);
     // Clear out the last data; this is important in the organized cloud case
     std::fill(cloud.data.begin(), cloud.data.end(), 0);
     if (config_.transform) {


### PR DESCRIPTION
Testing on a HDL64 S3, after much investigating, requires the vector to be larger to accommodate the larger amount of data. Otherwise a SIGSEGV occurs due to invalid memory access. This is only needed for the organized point cloud.

I am not aware if this change is needed for the HDL64 S2 or earlier devices, as I do not have access to these.