### PR TITLE
Passing fixed_frame and target_frame to Convert object.

### DIFF
--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -45,6 +45,8 @@
     <arg name="model" value="32E"/>
     <arg name="calibration" value="$(arg calibration)"/>
     <arg name="manager" value="$(arg manager)" />
+    <arg name="fixed_frame" value="$(arg frame_id)" />
+    <arg name="target_frame" value="$(arg frame_id)" />
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="organize_cloud" value="$(arg organize_cloud)"/>

--- a/velodyne_pointcloud/launch/64e_S3.launch
+++ b/velodyne_pointcloud/launch/64e_S3.launch
@@ -45,6 +45,8 @@
     <arg name="model" value="$(arg model)"/>
     <arg name="calibration" value="$(arg calibration)"/>
     <arg name="manager" value="$(arg manager)" />
+    <arg name="fixed_frame" value="$(arg frame_id)" />
+    <arg name="target_frame" value="$(arg frame_id)" />
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="min_range" value="$(arg min_range)"/>
   </include>

--- a/velodyne_pointcloud/launch/VLP-32C_points.launch
+++ b/velodyne_pointcloud/launch/VLP-32C_points.launch
@@ -45,6 +45,8 @@
     <arg name="model" value="32C"/>
     <arg name="calibration" value="$(arg calibration)"/>
     <arg name="manager" value="$(arg manager)" />
+    <arg name="fixed_frame" value="$(arg frame_id)" />
+    <arg name="target_frame" value="$(arg frame_id)" />
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="organize_cloud" value="$(arg organize_cloud)"/>

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -45,6 +45,8 @@
     <arg name="model" value="VLP16"/>
     <arg name="calibration" value="$(arg calibration)"/>
     <arg name="manager" value="$(arg manager)" />
+    <arg name="fixed_frame" value="$(arg frame_id)" />
+    <arg name="target_frame" value="$(arg frame_id)" />
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="organize_cloud" value="$(arg organize_cloud)"/>

--- a/velodyne_pointcloud/launch/cloud_nodelet.launch
+++ b/velodyne_pointcloud/launch/cloud_nodelet.launch
@@ -5,6 +5,8 @@
   <arg name="model" default="" />
   <arg name="calibration" default="" />
   <arg name="manager" default="velodyne_nodelet_manager" />
+  <arg name="fixed_frame" default="velodyne" />
+  <arg name="target_frame" default="velodyne" />
   <arg name="max_range" default="130.0" />
   <arg name="min_range" default="0.9" />
   <arg name="organize_cloud" default="false" />
@@ -13,6 +15,8 @@
         args="load velodyne_pointcloud/CloudNodelet $(arg manager)">
     <param name="model" value="$(arg model)"/>
     <param name="calibration" value="$(arg calibration)"/>
+    <param name="fixed_frame" value="$(arg fixed_frame)"/>
+    <param name="target_frame" value="$(arg target_frame)"/>
     <param name="max_range" value="$(arg max_range)"/>
     <param name="min_range" value="$(arg min_range)"/>
     <param name="organize_cloud" value="$(arg organize_cloud)"/>

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -25,6 +25,12 @@ namespace velodyne_pointcloud
     data_(new velodyne_rawdata::RawData()), first_rcfg_call(true),
     diagnostics_(node, private_nh, node_name)
   {
+    // Get startup parameters
+    private_nh.param<std::string>("fixed_frame", config_.fixed_frame, "velodyne");
+    private_nh.param<std::string>("target_Frame", config_.target_frame, "velodyne");
+    private_nh.param<double>("min_range", config_.min_range, 10.0);
+    private_nh.param<double>("max_range", config_.max_range, 200.0);
+    private_nh.param<bool>("organize_cloud", config_.organize_cloud, false);
 
     boost::optional<velodyne_pointcloud::Calibration> calibration = data_->setup(private_nh);
     if(calibration)


### PR DESCRIPTION
Several parameters were not being correctly passed to the `Convert` object causing things like the `frame_id` to be ignored. This PR fixes that issue.