### PR TITLE
More fixing of dependencies.

### DIFF
--- a/velodyne_pointcloud/package.xml
+++ b/velodyne_pointcloud/package.xml
@@ -32,7 +32,6 @@
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/velodyne_pointcloud/package.xml
+++ b/velodyne_pointcloud/package.xml
@@ -31,6 +31,8 @@
   <depend>velodyne_msgs</depend>
   <depend>yaml-cpp</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/velodyne_pointcloud/src/lib/CMakeLists.txt
+++ b/velodyne_pointcloud/src/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(velodyne_cloud_types SHARED
   organized_cloudXYZIR.cpp
 )
 ament_target_dependencies(velodyne_cloud_types
+  rclcpp
   sensor_msgs
   tf2
   velodyne_msgs

--- a/velodyne_pointcloud/tests/CMakeLists.txt
+++ b/velodyne_pointcloud/tests/CMakeLists.txt
@@ -3,7 +3,9 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(test_row_step test_row_step.cpp)
 ament_target_dependencies(test_row_step
+  geometry_msgs
   rclcpp
+  sensor_msgs
   tf2
   velodyne_msgs
 )


### PR DESCRIPTION
1.  Ensure that package.xml lists all of the test dependencies
needed.
2.  Ensure that velodyne_cloud_types depends on rclcpp.
3.  Make sure test_row_step depends on geometry_msgs and
sensor_msgs.  It doesn't have any *direct* dependencies on
them, but it includes datacontainerbase.hpp which does have
direct dependencies.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>