### PR TITLE
Velodyne pcl

### DIFF
--- a/velodyne_pcl/CMakeLists.txt
+++ b/velodyne_pcl/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(velodyne_pcl)
 
-find_package(catkin REQUIRED COMPONENTS pcl_ros)
+find_package(catkin REQUIRED COMPONENTS pcl_ros roslint)
+
+roslint_cpp()
+
+if(CATKIN_ENABLE_TESTING)
+  roslint_add_test()
+endif()
 
 catkin_package(
   INCLUDE_DIRS include

--- a/velodyne_pcl/CMakeLists.txt
+++ b/velodyne_pcl/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(velodyne_pcl)
+
+find_package(catkin REQUIRED COMPONENTS pcl_ros)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS pcl_ros
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)
+

--- a/velodyne_pcl/CMakeLists.txt
+++ b/velodyne_pcl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(velodyne_pcl)
 
 find_package(catkin REQUIRED COMPONENTS pcl_ros roslint)

--- a/velodyne_pcl/README.md
+++ b/velodyne_pcl/README.md
@@ -1,0 +1,32 @@
+## PointCloud2 to PCL PointCloud Conversion
+
+Convert `sensor_msgs::PointCloud2` objects coming from the velodyne_pointcloud driver to `pcl::PointCloud<velodyne_pcl::PointXYZIRT>` objects.
+
+The `sensor_msgs::PointCloud2` ROS message is constructed by using the `PointcloudXYZIRT`, or the `OrganizedCloudXYZIRT` container.
+Both define the following channels:
+
+* x - The x coord in Cartesian coordinates
+* y - The y coord in Cartesian coordinates
+* z - The z coord in Cartesian coordinates
+* intensity - The measured intensity at the point
+* ring - The ring number of the laser
+* time - The time stamp of the measured point
+
+To convert a `sensor_msgs::PointCloud2` published by the velodyne driver to PCL you could use the following code:
+
+```
+#include <pcl_conversions/pcl_conversions.h>
+#include <velodyne_pcl/point_types.h>
+#include <pcl/PCLPointCloud2.h>
+#include <pcl/conversions.h>
+
+void cloud_callback(const boost::shared_ptr<const sensor_msgs::PointCloud2>& cloud){
+
+  pcl::PCLPointCloud2 pcl_pointcloud2;
+  pcl_conversions::toPCL(*cloud, pcl_pointcloud2);
+  pcl::PointCloud<velodyne_pcl::PointXYZIRT>::Ptr pcl_cloud_ptr(new pcl::PointCloud<velodyne_pcl::PointXYZIRT>);
+  pcl::fromPCLPointCloud2(pcl_pointcloud2, *pcl_cloud_ptr);
+
+  // use pcl_cloud_ptr
+}
+```

--- a/velodyne_pcl/include/velodyne_pcl/point_types.h
+++ b/velodyne_pcl/include/velodyne_pcl/point_types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012 - 2020 Austin Robot Technology, Jesse Vera, Jack O'Quin, Piyush Khandelwal, Joshua Whitley, Sebastian Pütz
+// Copyright (C) 2012 - 2020 Austin Robot Technology, Jesse Vera, Jack O'Quin, Piyush Khandelwal, Joshua Whitley, Sebastian Pütz  // NOLINT
 // All rights reserved.
 //
 // Software License Agreement (BSD License 2.0)
@@ -64,6 +64,6 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(velodyne_pcl::PointXYZIR,
                                   (float, z, z)
                                   (float, intensity, intensity)
                                   (uint16_t, ring, ring)
-				  (float, time, time))
+                                  (float, time, time))
 
 #endif  // VELODYNE_PCL_POINT_TYPES_H

--- a/velodyne_pcl/include/velodyne_pcl/point_types.h
+++ b/velodyne_pcl/include/velodyne_pcl/point_types.h
@@ -1,0 +1,69 @@
+// Copyright (C) 2012 - 2020 Austin Robot Technology, Jesse Vera, Jack O'Quin, Piyush Khandelwal, Joshua Whitley, Sebastian Pütz
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of {copyright_holder} nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/** \file
+ *
+ *  Point Cloud Library point structures for Velodyne data.
+ *
+ *  @author Jesse Vera
+ *  @author Jack O'Quin
+ *  @author Piyush Khandelwal
+ *  @author Sebastian Pütz
+ */
+
+#ifndef VELODYNE_PCL_POINT_TYPES_H
+#define VELODYNE_PCL_POINT_TYPES_H
+
+#include <pcl/point_types.h>
+
+namespace velodyne_pcl
+{
+struct PointXYZIRT
+{
+  PCL_ADD_POINT4D;                    // quad-word XYZ
+  float    intensity;                 ///< laser intensity reading
+  uint16_t ring;                      ///< laser ring number
+  float    time;                      ///< laser time reading
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // ensure proper alignment
+}
+EIGEN_ALIGN16;
+}  // namespace velodyne_pcl
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(velodyne_pcl::PointXYZIR,
+                                  (float, x, x)
+                                  (float, y, y)
+                                  (float, z, z)
+                                  (float, intensity, intensity)
+                                  (uint16_t, ring, ring)
+				  (float, time, time))
+
+#endif  // VELODYNE_PCL_POINT_TYPES_H

--- a/velodyne_pcl/package.xml
+++ b/velodyne_pcl/package.xml
@@ -13,7 +13,8 @@
   <url type="repository">https://github.com/ros-drivers/velodyne</url>
   <url type="bugtracker">https://github.com/ros-drivers/velodyne/issues</url>
 
-  <depend>pcl_ros</depend>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roslint</build_depend>
+  <depend>pcl_ros</depend>
 
 </package>

--- a/velodyne_pcl/package.xml
+++ b/velodyne_pcl/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>velodyne_pcl</name>
+  <version>0.0.0</version>
+  <description>The velodyne_pcl package</description>
+
+  <maintainer email="josh.whitley@autoware.org">Josh Whitley</maintainer>
+  <author>Sebastian Pütz</author>
+
+  <license>BSD</license>
+
+  <url type="website">http://wiki.ros.org/velodyne_pcl</url>
+  <url type="repository">https://github.com/ros-drivers/velodyne</url>
+  <url type="bugtracker">https://github.com/ros-drivers/velodyne/issues</url>
+
+  <depend>pcl_ros</depend>
+  <buildtool_depend>catkin</buildtool_depend>
+
+</package>

--- a/velodyne_pcl/package.xml
+++ b/velodyne_pcl/package.xml
@@ -1,5 +1,5 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>velodyne_pcl</name>
   <version>1.5.2</version>
   <description>The velodyne_pcl package</description>

--- a/velodyne_pcl/package.xml
+++ b/velodyne_pcl/package.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>velodyne_pcl</name>
-  <version>0.0.0</version>
+  <version>1.5.2</version>
   <description>The velodyne_pcl package</description>
 
   <maintainer email="josh.whitley@autoware.org">Josh Whitley</maintainer>

--- a/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIRT.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIRT.h
@@ -30,8 +30,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIR_H
-#define VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIR_H
+#ifndef VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIRT_H
+#define VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIRT_H
 
 #include <velodyne_pointcloud/datacontainerbase.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
@@ -39,10 +39,10 @@
 
 namespace velodyne_pointcloud
 {
-class OrganizedCloudXYZIR : public velodyne_rawdata::DataContainerBase
+class OrganizedCloudXYZIRT : public velodyne_rawdata::DataContainerBase
 {
 public:
-  OrganizedCloudXYZIR(const double max_range, const double min_range, const std::string& target_frame,
+  OrganizedCloudXYZIRT(const double max_range, const double min_range, const std::string& target_frame,
                       const std::string& fixed_frame, const unsigned int num_lasers, const unsigned int scans_per_block,
                       boost::shared_ptr<tf::TransformListener> tf_ptr = boost::shared_ptr<tf::TransformListener>());
 
@@ -58,4 +58,4 @@ private:
   sensor_msgs::PointCloud2Iterator<uint16_t> iter_ring;
 };
 } /* namespace velodyne_pointcloud */
-#endif  // VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIR_H
+#endif  // VELODYNE_POINTCLOUD_ORGANIZED_CLOUDXYZIRT_H

--- a/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIRT.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIRT.h
@@ -30,18 +30,18 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef VELODYNE_POINTCLOUD_POINTCLOUDXYZIR_H
-#define VELODYNE_POINTCLOUD_POINTCLOUDXYZIR_H
+#ifndef VELODYNE_POINTCLOUD_POINTCLOUDXYZIRT_H
+#define VELODYNE_POINTCLOUD_POINTCLOUDXYZIRT_H
 
 #include <velodyne_pointcloud/datacontainerbase.h>
 #include <string>
 
 namespace velodyne_pointcloud
 {
-class PointcloudXYZIR : public velodyne_rawdata::DataContainerBase
+class PointcloudXYZIRT : public velodyne_rawdata::DataContainerBase
 {
 public:
-  PointcloudXYZIR(const double max_range, const double min_range, const std::string& target_frame,
+  PointcloudXYZIRT(const double max_range, const double min_range, const std::string& target_frame,
                   const std::string& fixed_frame, const unsigned int scans_per_block,
                   boost::shared_ptr<tf::TransformListener> tf_ptr = boost::shared_ptr<tf::TransformListener>());
 
@@ -57,4 +57,4 @@ public:
 };
 }  // namespace velodyne_pointcloud
 
-#endif  // VELODYNE_POINTCLOUD_POINTCLOUDXYZIR_H
+#endif  // VELODYNE_POINTCLOUD_POINTCLOUDXYZIRT_H

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.h
@@ -49,7 +49,7 @@
 #include <sensor_msgs/PointCloud2.h>
 
 #include <velodyne_pointcloud/rawdata.h>
-#include <velodyne_pointcloud/pointcloudXYZIR.h>
+#include <velodyne_pointcloud/pointcloudXYZIRT.h>
 
 #include <dynamic_reconfigure/server.h>
 #include <velodyne_pointcloud/TransformNodeConfig.h>

--- a/velodyne_pointcloud/src/conversions/CMakeLists.txt
+++ b/velodyne_pointcloud/src/conversions/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_executable(cloud_node cloud_node.cc convert.cc pointcloudXYZIR.cc organized_cloudXYZIR.cc)
+add_executable(cloud_node cloud_node.cc convert.cc pointcloudXYZIRT.cc organized_cloudXYZIRT.cc)
 add_dependencies(cloud_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(cloud_node velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS cloud_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(cloud_nodelet cloud_nodelet.cc convert.cc pointcloudXYZIR.cc organized_cloudXYZIR.cc)
+add_library(cloud_nodelet cloud_nodelet.cc convert.cc pointcloudXYZIRT.cc organized_cloudXYZIRT.cc)
 add_dependencies(cloud_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(cloud_nodelet velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
@@ -14,14 +14,14 @@ install(TARGETS cloud_nodelet
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-add_executable(transform_node transform_node.cc transform.cc pointcloudXYZIR.cc organized_cloudXYZIR.cc)
+add_executable(transform_node transform_node.cc transform.cc pointcloudXYZIRT.cc organized_cloudXYZIRT.cc)
 add_dependencies(transform_node ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(transform_node velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
 install(TARGETS transform_node
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_library(transform_nodelet transform_nodelet.cc transform.cc pointcloudXYZIR.cc organized_cloudXYZIR.cc)
+add_library(transform_nodelet transform_nodelet.cc transform.cc pointcloudXYZIRT.cc organized_cloudXYZIRT.cc)
 add_dependencies(transform_nodelet ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(transform_nodelet velodyne_rawdata
                       ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -15,8 +15,8 @@
 
 #include "velodyne_pointcloud/convert.h"
 
-#include <velodyne_pointcloud/pointcloudXYZIR.h>
-#include <velodyne_pointcloud/organized_cloudXYZIR.h>
+#include <velodyne_pointcloud/pointcloudXYZIRT.h>
+#include <velodyne_pointcloud/organized_cloudXYZIRT.h>
 
 namespace velodyne_pointcloud
 {
@@ -45,15 +45,15 @@ namespace velodyne_pointcloud
 
     if(config_.organize_cloud)
     {
-      container_ptr_ = boost::shared_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
+      container_ptr_ = boost::shared_ptr<OrganizedCloudXYZIRT>(
+          new OrganizedCloudXYZIRT(config_.max_range, config_.min_range,
               config_.target_frame, config_.fixed_frame,
               config_.num_lasers, data_->scansPerPacket()));
     }
     else
     {
-      container_ptr_ = boost::shared_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.max_range, config_.min_range,
+      container_ptr_ = boost::shared_ptr<PointcloudXYZIRT>(
+          new PointcloudXYZIRT(config_.max_range, config_.min_range,
               config_.target_frame, config_.fixed_frame,
               data_->scansPerPacket()));
     }
@@ -107,15 +107,15 @@ namespace velodyne_pointcloud
         if(config_.organize_cloud) // TODO only on change
         {
             ROS_INFO_STREAM("Using the organized cloud format...");
-            container_ptr_ = boost::shared_ptr<OrganizedCloudXYZIR>(
-                new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
+            container_ptr_ = boost::shared_ptr<OrganizedCloudXYZIRT>(
+                new OrganizedCloudXYZIRT(config_.max_range, config_.min_range,
                     config_.target_frame, config_.fixed_frame,
                     config_.num_lasers, data_->scansPerPacket()));
         }
         else
         {
-            container_ptr_ = boost::shared_ptr<PointcloudXYZIR>(
-                new PointcloudXYZIR(config_.max_range, config_.min_range,
+            container_ptr_ = boost::shared_ptr<PointcloudXYZIRT>(
+                new PointcloudXYZIRT(config_.max_range, config_.min_range,
                     config_.target_frame, config_.fixed_frame,
                     data_->scansPerPacket()));
         }

--- a/velodyne_pointcloud/src/conversions/organized_cloudXYZIR.cc
+++ b/velodyne_pointcloud/src/conversions/organized_cloudXYZIR.cc
@@ -64,7 +64,7 @@ namespace velodyne_pointcloud
       *(iter_z+ring) = z;
       *(iter_intensity+ring) = intensity;
       *(iter_ring+ring) = ring;
-      *(iter_time+time) = time;
+      *(iter_time+ring) = time;
     }
     else
     {
@@ -73,7 +73,7 @@ namespace velodyne_pointcloud
       *(iter_z+ring) = nanf("");
       *(iter_intensity+ring) = nanf("");
       *(iter_ring+ring) = ring;
-      *(iter_time+time) = time;
+      *(iter_time+ring) = time;
     }
   }
 }

--- a/velodyne_pointcloud/src/conversions/organized_cloudXYZIRT.cc
+++ b/velodyne_pointcloud/src/conversions/organized_cloudXYZIRT.cc
@@ -1,10 +1,9 @@
 
-#include <velodyne_pointcloud/organized_cloudXYZIR.h>
+#include <velodyne_pointcloud/organized_cloudXYZIRT.h>
 
 namespace velodyne_pointcloud
 {
-
-  OrganizedCloudXYZIR::OrganizedCloudXYZIR(
+OrganizedCloudXYZIRT::OrganizedCloudXYZIRT(
       const double max_range, const double min_range,
       const std::string& target_frame, const std::string& fixed_frame,
       const unsigned int num_lasers, const unsigned int scans_per_block,
@@ -23,7 +22,7 @@ namespace velodyne_pointcloud
   {
   }
 
-  void OrganizedCloudXYZIR::newLine()
+  void OrganizedCloudXYZIRT::newLine()
   {
     iter_x = iter_x + config_.init_width;
     iter_y = iter_y + config_.init_width;
@@ -34,7 +33,7 @@ namespace velodyne_pointcloud
     ++cloud.height;
   }
 
-  void OrganizedCloudXYZIR::setup(const velodyne_msgs::VelodyneScan::ConstPtr& scan_msg){
+  void OrganizedCloudXYZIRT::setup(const velodyne_msgs::VelodyneScan::ConstPtr& scan_msg){
     DataContainerBase::setup(scan_msg);
     iter_x = sensor_msgs::PointCloud2Iterator<float>(cloud, "x");
     iter_y = sensor_msgs::PointCloud2Iterator<float>(cloud, "y");
@@ -45,7 +44,7 @@ namespace velodyne_pointcloud
   }
 
 
-  void OrganizedCloudXYZIR::addPoint(float x, float y, float z,
+  void OrganizedCloudXYZIRT::addPoint(float x, float y, float z,
       const uint16_t ring, const uint16_t /*azimuth*/, const float distance, const float intensity, const float time)
   {
     /** The laser values are not ordered, the organized structure

--- a/velodyne_pointcloud/src/conversions/pointcloudXYZIRT.cc
+++ b/velodyne_pointcloud/src/conversions/pointcloudXYZIRT.cc
@@ -1,12 +1,11 @@
 
 
 
-#include <velodyne_pointcloud/pointcloudXYZIR.h>
+#include <velodyne_pointcloud/pointcloudXYZIRT.h>
 
 namespace velodyne_pointcloud 
 {
-
-  PointcloudXYZIR::PointcloudXYZIR(
+PointcloudXYZIRT::PointcloudXYZIRT(
     const double max_range, const double min_range,
     const std::string& target_frame, const std::string& fixed_frame,
     const unsigned int scans_per_block, boost::shared_ptr<tf::TransformListener> tf_ptr)
@@ -23,7 +22,7 @@ namespace velodyne_pointcloud
         iter_ring(cloud, "ring"), iter_intensity(cloud, "intensity"), iter_time(cloud, "time")
     {};
 
-  void PointcloudXYZIR::setup(const velodyne_msgs::VelodyneScan::ConstPtr& scan_msg){
+  void PointcloudXYZIRT::setup(const velodyne_msgs::VelodyneScan::ConstPtr& scan_msg){
     DataContainerBase::setup(scan_msg);
     iter_x = sensor_msgs::PointCloud2Iterator<float>(cloud, "x");
     iter_y = sensor_msgs::PointCloud2Iterator<float>(cloud, "y");
@@ -33,10 +32,10 @@ namespace velodyne_pointcloud
     iter_time = sensor_msgs::PointCloud2Iterator<float >(cloud, "time");
   }
 
-  void PointcloudXYZIR::newLine()
+  void PointcloudXYZIRT::newLine()
   {}
 
-  void PointcloudXYZIR::addPoint(float x, float y, float z, uint16_t ring, uint16_t /*azimuth*/, float distance, float intensity, float time)
+  void PointcloudXYZIRT::addPoint(float x, float y, float z, uint16_t ring, uint16_t /*azimuth*/, float distance, float intensity, float time)
   {
     if(!pointInRange(distance)) return;
 

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -20,8 +20,8 @@
 
 #include "velodyne_pointcloud/transform.h"
 
-#include <velodyne_pointcloud/pointcloudXYZIR.h>
-#include <velodyne_pointcloud/organized_cloudXYZIR.h>
+#include <velodyne_pointcloud/pointcloudXYZIRT.h>
+#include <velodyne_pointcloud/organized_cloudXYZIRT.h>
 
 namespace velodyne_pointcloud
 {
@@ -48,14 +48,14 @@ namespace velodyne_pointcloud
 
     if(config_.organize_cloud)
     {
-      container_ptr = boost::shared_ptr<OrganizedCloudXYZIR>(
-          new OrganizedCloudXYZIR(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
+      container_ptr = boost::shared_ptr<OrganizedCloudXYZIRT>(
+          new OrganizedCloudXYZIRT(config_.max_range, config_.min_range, config_.target_frame, config_.fixed_frame,
                                   config_.num_lasers, data_->scansPerPacket(), tf_ptr_));
     }
     else
     {
-      container_ptr = boost::shared_ptr<PointcloudXYZIR>(
-          new PointcloudXYZIR(config_.max_range, config_.min_range,
+      container_ptr = boost::shared_ptr<PointcloudXYZIRT>(
+          new PointcloudXYZIRT(config_.max_range, config_.min_range,
                               config_.target_frame, config_.fixed_frame,
                               data_->scansPerPacket(), tf_ptr_));
     }
@@ -110,15 +110,15 @@ namespace velodyne_pointcloud
       if(config_.organize_cloud)
       {
         ROS_INFO_STREAM("Using the organized cloud format...");
-        container_ptr = boost::shared_ptr<OrganizedCloudXYZIR>(
-            new OrganizedCloudXYZIR(config_.max_range, config_.min_range,
+        container_ptr = boost::shared_ptr<OrganizedCloudXYZIRT>(
+            new OrganizedCloudXYZIRT(config_.max_range, config_.min_range,
                                     config_.target_frame, config_.fixed_frame,
                                     config_.num_lasers, data_->scansPerPacket()));
       }
       else
       {
-        container_ptr = boost::shared_ptr<PointcloudXYZIR>(
-            new PointcloudXYZIR(config_.max_range, config_.min_range,
+        container_ptr = boost::shared_ptr<PointcloudXYZIRT>(
+            new PointcloudXYZIRT(config_.max_range, config_.min_range,
                                 config_.target_frame, config_.fixed_frame,
                                 data_->scansPerPacket()));
       }


### PR DESCRIPTION
Regrading #287 The `velodyne_pcl` ROS package restores the conversion file `point_types.h`.
The README explains how to use it.

The following has been done:
- Fixed assignment of the time value in the organized point cloud container
- Added `velodyne_pcl` ROS package with the `point_types.h` header file.
- Added a RAEDME.md file to explain how to convert velodyne ROS point clouds to PCL
- Renamed both containers to cover the previously added time property. 