### PR TITLE
Fix typo in velodyne_pcl/point_types.h

### DIFF
--- a/velodyne_pcl/include/velodyne_pcl/point_types.h
+++ b/velodyne_pcl/include/velodyne_pcl/point_types.h
@@ -58,7 +58,7 @@ struct PointXYZIRT
 EIGEN_ALIGN16;
 }  // namespace velodyne_pcl
 
-POINT_CLOUD_REGISTER_POINT_STRUCT(velodyne_pcl::PointXYZIR,
+POINT_CLOUD_REGISTER_POINT_STRUCT(velodyne_pcl::PointXYZIRT,
                                   (float, x, x)
                                   (float, y, y)
                                   (float, z, z)


### PR DESCRIPTION
Fixes an issue where the POINT_CLOUD_REGISTER_POINT_STRUCT function was using the old PointXYZIR and not PointXYZIRT.