### PR TITLE
PCAP timestamps & PCAP+GPS timestamps

### DIFF
--- a/velodyne_driver/include/velodyne_driver/input.h
+++ b/velodyne_driver/include/velodyne_driver/input.h
@@ -139,6 +139,7 @@ private:
   bpf_program pcap_packet_filter_;
   char errbuf_[PCAP_ERRBUF_SIZE];
   bool empty_;
+  bool pcap_time_;
   bool read_once_;
   bool read_fast_;
   double repeat_delay_;

--- a/velodyne_driver/include/velodyne_driver/time_conversion.hpp
+++ b/velodyne_driver/include/velodyne_driver/time_conversion.hpp
@@ -59,7 +59,7 @@ ros::Time resolveHourAmbiguity(const ros::Time &stamp, const ros::Time &nominal_
     return retval;
 }
 
-ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data) {
+ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data, const struct pcap_pkthdr *header = NULL) {
     const int HOUR_TO_SEC = 3600;
     // time for each packet is a 4 byte uint
     // It is the number of microseconds from the top of the hour
@@ -67,7 +67,13 @@ ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data) {
                                   ((uint32_t) data[2] ) << 16 |
                                   ((uint32_t) data[1] ) << 8 |
                                   ((uint32_t) data[0] ));
-    ros::Time time_nom = ros::Time::now(); // use this to recover the hour
+    ros::Time time_nom = ros::Time();
+    // if header is NULL, assume real time operation
+    if (!header) {
+        time_nom = ros::Time::now(); // use this to recover the hour
+    } else {
+        time_nom = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000);
+    }
     uint32_t cur_hour = time_nom.sec / HOUR_TO_SEC;
     ros::Time stamp = ros::Time((cur_hour * HOUR_TO_SEC) + (usecs / 1000000),
                                 (usecs % 1000000) * 1000);

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -14,6 +14,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
+  <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
 
@@ -33,6 +34,7 @@
     <param name="repeat_delay" value="$(arg repeat_delay)"/>
     <param name="rpm" value="$(arg rpm)"/>
     <param name="gps_time" value="$(arg gps_time)"/>
+    <param name="pcap_time" value="$(arg pcap_time)"/>
     <param name="cut_angle" value="$(arg cut_angle)"/>
     <param name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </node>    

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -262,6 +262,7 @@ namespace velodyne_driver
     private_nh.param("read_once", read_once_, false);
     private_nh.param("read_fast", read_fast_, false);
     private_nh.param("repeat_delay", repeat_delay_, 0.0);
+    private_nh.param("pcap_time", pcap_time_, false);
 
     if (read_once_)
       ROS_INFO("Read input file only once.");
@@ -317,7 +318,21 @@ namespace velodyne_driver
               packet_rate_.sleep();
             
             memcpy(&pkt->data[0], pkt_data+42, packet_size);
-            pkt->stamp = ros::Time::now(); // time_offset not considered here, as no synchronization required
+            if (!gps_time_) {
+              if (!pcap_time_) {
+                pkt->stamp = ros::Time::now(); // time_offset not considered here, as no synchronization required
+              } else {
+                pkt->stamp = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000); // 
+              }
+            } else {
+              if (!pcap_time_) {
+                pkt->stamp = ros::Time::now(); // correcting ros::Time::now() using GPS from PCAP is an invalid parameter combination, so just return ros::Time::now()
+              } else {
+                // time for each packet is a 4 byte uint located starting at offset 1200 in
+                // the data packet
+                pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]), header);
+              }
+            }
             empty_ = false;
             return 0;                   // success
           }

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -325,13 +325,9 @@ namespace velodyne_driver
                 pkt->stamp = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000); // 
               }
             } else {
-              if (!pcap_time_) {
-                pkt->stamp = ros::Time::now(); // correcting ros::Time::now() using GPS from PCAP is an invalid parameter combination, so just return ros::Time::now()
-              } else {
-                // time for each packet is a 4 byte uint located starting at offset 1200 in
-                // the data packet
-                pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]), header);
-              }
+              // time for each packet is a 4 byte uint located starting at offset 1200 in
+              // the data packet
+              pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]), header);
             }
             empty_ = false;
             return 0;                   // success

--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -17,6 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
+  <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
@@ -36,6 +37,7 @@
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="gps_time" value="$(arg gps_time)"/>
+    <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>

--- a/velodyne_pointcloud/launch/64e_S3.launch
+++ b/velodyne_pointcloud/launch/64e_S3.launch
@@ -17,6 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
+  <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
@@ -36,6 +37,7 @@
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="gps_time" value="$(arg gps_time)"/>
+    <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>

--- a/velodyne_pointcloud/launch/VLP-32C_points.launch
+++ b/velodyne_pointcloud/launch/VLP-32C_points.launch
@@ -17,6 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
+  <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
@@ -36,6 +37,7 @@
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="gps_time" value="$(arg gps_time)"/>
+    <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -17,6 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
+  <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
@@ -36,6 +37,7 @@
     <arg name="repeat_delay" value="$(arg repeat_delay)"/>
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="gps_time" value="$(arg gps_time)"/>
+    <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>


### PR DESCRIPTION
This pull request continues on the work of #58 to add the ability to timestamp the published topics using the timestamp in the PCAP headers. I have also added the GPS time correction from #222 so that the PCAP ethernet header time can be corrected using the GPS time inside the Velodyne packet.

It handles the following combinations of the time parameters:
- `gps_time == false` and `pcap_time == false`: Sets time to `ros::Time::now()`
- `gps_time == false` and `pcap_time == true`: Sets time to the time in the PCAP ethernet headers
- `gps_time == true` and `pcap_time == false`: Sets time to `ros::Time::now()`, because this is an invalid combination of parameters
- `gps_time == true` and `pcap_time == true`: Sets time to the time in the PCAP ethernet headers and then uses the function from #222 to adjust it to GPS time

Looking at the respective info printouts for the PCAP and the bag (pcap_time and gps_time enabled rather than realtime headers), the timestamping appears to be functioning correctly:
```
user@pc:~$ rosbag info survey.bag 
...
start:       Nov 30 2020 15:18:13.10 (1606749493.10)
end:         Nov 30 2020 15:23:05.19 (1606749785.19)
...

user@pc:~$ capinfos survey.pcap 
...
First packet time:   2020-11-30 15:18:12.890587
Last packet time:    2020-11-30 15:23:05.169158
...
```