### PR TITLE
Fixed row_step=0 when init_width=0 (dense cloud)

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.h
@@ -119,6 +119,7 @@ public:
   const sensor_msgs::PointCloud2& finishCloud()
   {
     cloud.data.resize(cloud.point_step * cloud.width * cloud.height);
+    cloud.row_step = cloud.point_step * cloud.width;
 
     if (!config_.target_frame.empty())
     {


### PR DESCRIPTION
The PointCloud2 msg will be then valid: http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointCloud2.html

Referred issues:
 * https://answers.ros.org/question/377470/rtabmap-icp_odometrycpp453callbackcloud-fatal-error/
 * http://official-rtab-map-forum.67519.x6.nabble.com/Condition-scan3dMsg-data-size-scan3dMsg-row-step-scan3dMsg-height-not-met-td7852.html