### PR TITLE
add missing include to pcap.h that prevents tests from being built

### DIFF
--- a/velodyne_driver/include/velodyne_driver/time_conversion.hpp
+++ b/velodyne_driver/include/velodyne_driver/time_conversion.hpp
@@ -33,6 +33,8 @@
 #ifndef VELODYNE_DRIVER_TIME_CONVERSION_HPP
 #define VELODYNE_DRIVER_TIME_CONVERSION_HPP
 
+#include <pcap.h>
+
 #include <ros/ros.h>
 #include <ros/time.h>
 

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -44,15 +44,17 @@
  *              PCAP dump
  */
 
-#include <unistd.h>
-#include <string>
-#include <sstream>
-#include <sys/socket.h>
 #include <arpa/inet.h>
-#include <poll.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <pcap.h>
+#include <poll.h>
+#include <string>
+#include <sstream>
 #include <sys/file.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <velodyne_driver/input.h>
 #include <velodyne_driver/time_conversion.hpp>
 


### PR DESCRIPTION
This PR fixes a problem introduced with PR #384 that broke compilation of the tests for velodyne_driver. Maybe @HMellor and @JWhitleyWork can have a brief look.

The tests actually failed to compile there as well, but for some reason the CI did not catch this as a failure:
https://github.com/ros-drivers/velodyne/runs/2571172566?check_suite_focus=true

Try the following to reproduce:

```
catkin build velodyne_driver --catkin-make-args run_tests
```
which leads to:

```
[ 75%] Built target velodyne_driver_tests_vlp16.pcap
[ 75%] Built target velodyne_driver_tests_class.pcap
In file included from /home/user/catkin_ws/src/velodyne/velodyne_driver/tests/timeconversiontest.cpp:33:
/home/user/catkin_ws/src/velodyne/velodyne_driver/include/velodyne_driver/time_conversion.hpp: In function ‘ros::Time rosTimeFromGpsTimestamp(const uint8_t*, const pcap_pkthdr*)’:
/home/user/catkin_ws/src/velodyne/velodyne_driver/include/velodyne_driver/time_conversion.hpp:75:36: error: invalid use of incomplete type ‘const struct pcap_pkthdr’
   75 |         time_nom = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000);
      |                                    ^~
/home/user/catkin_ws/src/velodyne/velodyne_driver/include/velodyne_driver/time_conversion.hpp:62:76: note: forward declaration of ‘struct pcap_pkthdr’
   62 | ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data, const struct pcap_pkthdr *header = NULL) {
      |                                                                            ^~~~~~~~~~~
/home/user/catkin_ws/src/velodyne/velodyne_driver/include/velodyne_driver/time_conversion.hpp:75:55: error: invalid use of incomplete type ‘const struct pcap_pkthdr’
   75 |         time_nom = ros::Time(header->ts.tv_sec, header->ts.tv_usec * 1000);
      |                                                       ^~
/home/user/catkin_ws/src/velodyne/velodyne_driver/include/velodyne_driver/time_conversion.hpp:62:76: note: forward declaration of ‘struct pcap_pkthdr’
   62 | ros::Time rosTimeFromGpsTimestamp(const uint8_t * const data, const struct pcap_pkthdr *header = NULL) {
      |                                                                            ^~~~~~~~~~~
make[3]: *** [CMakeFiles/time_test.dir/build.make:63: CMakeFiles/time_test.dir/tests/timeconversiontest.cpp.o] Error 1
make[3]: Leaving directory '/home/user/catkin_ws/build/velodyne_driver'
make[2]: *** [CMakeFiles/Makefile2:2224: CMakeFiles/time_test.dir/all] Error 2
make[2]: Leaving directory '/home/user/catkin_ws/build/velodyne_driver'
make[1]: *** [CMakeFiles/Makefile2:1905: CMakeFiles/run_tests.dir/rule] Error 2
make[1]: Leaving directory '/home/user/catkin_ws/build/velodyne_driver'
make: *** [Makefile:942: run_tests] Error 2
cd /home/user/catkin_ws/build/velodyne_driver; catkin build --get-env velodyne_driver | catkin env -si  /usr/bin/make run_tests --jobserver-auth=3,4; cd -
..................................................................................................................................................................................................................
Failed     << velodyne_driver:make           [ Exited with code 2 ]                                                                                                                                               
Failed    <<< velodyne_driver                [ 6.1 seconds ]                                                                                                                                                      
[build] Summary: 0 of 1 packages succeeded.
```
