### PR TITLE
fix crashes when using vls128 in organized mode

### DIFF
--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -626,7 +626,12 @@ void RawData::unpack_vls128(const velodyne_msgs::VelodynePacket &pkt, DataContai
                         time);
         }
       }
-      data.newLine();
+
+      if (current_block.header == VLS128_BANK_4)
+      {
+        // add a new line only after the last bank (VLS128_BANK_4)
+        data.newLine();
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug in `RawData::unpack_vls128()` which leads to the driver crashing when `organize_cloud` is enabled.

*Steps to reproduce:*
 * Start the driver with organize_cloud set to true:
`roslaunch velodyne_pointcloud VLS128_points.launch organize_cloud:=true`
 * Subscribe to `velodyne_points`
 * The driver will crash with `[velodyne_nodelet_manager-1] process has died `

*Explanation and fix:*
 * The current implementation of `RawData::unpack_vls128()` starts a new line of the point cloud after each block. A block in case of the vls128 , however, only contains data from a bank of 32 of the 128 lasers. A line of the point cloud must therefore consist of four blocks, i.e. data of four banks.
 * The current implementation crashes because it tries to write far beyond the memory allocated for the cloud.
 * In my experiments, the blocks always arrived nicely ordered: `VLS128_BANK_1`, `VLS128_BANK_2`, `VLS128_BANK_3`, `VLS128_BANK_4`, so it was enough to start a new line after each block corresponding to `VLS128_BANK_4`.