### PR TITLE
reuse Velodyne UDP port

### DIFF
--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -116,6 +116,13 @@ namespace velodyne_driver
     my_addr.sin_port = htons(port);          // port in network byte order
     my_addr.sin_addr.s_addr = INADDR_ANY;    // automatically fill in my IP
   
+    // compatibility with Spot Core EAP, reuse port 2368
+    int val = 1;
+    if(setsockopt(sockfd_, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) == -1) {
+        perror("socketopt");
+        return;
+    }
+
     if (bind(sockfd_, (sockaddr *)&my_addr, sizeof(sockaddr)) == -1)
       {
         perror("bind");                 // TODO: ROS_ERROR errno


### PR DESCRIPTION
The Boston Dynamics Spot Core with the EAP (Enhanced Autonomy Package) version also binds to UDP port 2368 in its velodyne service, and without this update the ROS velodyne driver cannot bind to the port. It gives "Bind address already in use" warning and a "Cannot poll device" error. The reason is that, without setting the socket binding option to reuseable, it  locks away the UDP port from every other concurrent connection.