### PR TITLE
fix timing bug with offline use

### DIFF
--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -176,12 +176,14 @@ public:
    * through a communication overhead.
    *
    * @param calibration_file path to the calibration file
+   * @param model sensor model type
    * @param max_range_ cutoff for maximum range
    * @param min_range_ cutoff for minimum range
    * @returns 0 if successful;
    *           errno value for failure
    */
-  int setupOffline(std::string calibration_file, double max_range_, double min_range_);
+  int setupOffline(std::string calibration_file, std::string model, double max_range_, 
+                   double min_range_);
 
   void unpack(const velodyne_msgs::VelodynePacket& pkt, DataContainerBase& data,
               const ros::Time& scan_start_time);

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -253,8 +253,12 @@ inline float SQR(float val) { return val*val; }
   }
 
   /** Set up for offline operation */
-  int RawData::setupOffline(std::string calibration_file, double max_range_, double min_range_)
+  int RawData::setupOffline(std::string calibration_file,  std::string model, 
+                            double max_range_, double min_range_)
   {
+
+    config_.model = model;
+    buildTimings();
 
     config_.max_range = max_range_;
     config_.min_range = min_range_;


### PR DESCRIPTION
Currently when using the offline setup, it does not build the per-point timing offsets which means when unpacking the packets in the offline mode, you cannot timestamp each point with its packet time.
This PR does the following:

    - call buildTimings from setupOffline function
    - add model to setupOffline interface
    - set config model param which is needed by buildTimings