### PR TITLE
Replace deprecated argument names in launch

### DIFF
--- a/velodyne/launch/velodyne-all-nodes-VLP16-composed-launch.py
+++ b/velodyne/launch/velodyne-all-nodes-VLP16-composed-launch.py
@@ -58,25 +58,25 @@ def generate_launch_description():
         laserscan_params = yaml.safe_load(f)['velodyne_laserscan_node']['ros__parameters']
 
     container = ComposableNodeContainer(
-            node_name='velodyne_container',
-            node_namespace='',
+            name='velodyne_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_driver',
-                    node_plugin='velodyne_driver::VelodyneDriver',
-                    node_name='velodyne_driver_node',
+                    plugin='velodyne_driver::VelodyneDriver',
+                    name='velodyne_driver_node',
                     parameters=[driver_params]),
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Convert',
-                    node_name='velodyne_convert_node',
+                    plugin='velodyne_pointcloud::Convert',
+                    name='velodyne_convert_node',
                     parameters=[convert_params]),
                 ComposableNode(
                     package='velodyne_laserscan',
-                    node_plugin='velodyne_laserscan::VelodyneLaserScan',
-                    node_name='velodyne_laserscan_node',
+                    plugin='velodyne_laserscan::VelodyneLaserScan',
+                    name='velodyne_laserscan_node',
                     parameters=[laserscan_params]),
             ],
             output='both',

--- a/velodyne/launch/velodyne-all-nodes-VLP16-launch.py
+++ b/velodyne/launch/velodyne-all-nodes-VLP16-launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
     driver_share_dir = ament_index_python.packages.get_package_share_directory('velodyne_driver')
     driver_params_file = os.path.join(driver_share_dir, 'config', 'VLP16-velodyne_driver_node-params.yaml')
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
-                                                   node_executable='velodyne_driver_node',
+                                                   executable='velodyne_driver_node',
                                                    output='both',
                                                    parameters=[driver_params_file])
 
@@ -53,14 +53,14 @@ def generate_launch_description():
         convert_params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     convert_params['calibration'] = os.path.join(convert_share_dir, 'params', 'VLP16db.yaml')
     velodyne_convert_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                    node_executable='velodyne_convert_node',
+                                                    executable='velodyne_convert_node',
                                                     output='both',
                                                     parameters=[convert_params])
 
     laserscan_share_dir = ament_index_python.packages.get_package_share_directory('velodyne_laserscan')
     laserscan_params_file = os.path.join(laserscan_share_dir, 'config', 'default-velodyne_laserscan_node-params.yaml')
     velodyne_laserscan_node = launch_ros.actions.Node(package='velodyne_laserscan',
-                                                      node_executable='velodyne_laserscan_node',
+                                                      executable='velodyne_laserscan_node',
                                                       output='both',
                                                       parameters=[laserscan_params_file])
 

--- a/velodyne/launch/velodyne-all-nodes-VLP32C-composed-launch.py
+++ b/velodyne/launch/velodyne-all-nodes-VLP32C-composed-launch.py
@@ -58,25 +58,25 @@ def generate_launch_description():
         laserscan_params = yaml.safe_load(f)['velodyne_laserscan_node']['ros__parameters']
 
     container = ComposableNodeContainer(
-            node_name='velodyne_container',
-            node_namespace='',
+            name='velodyne_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_driver',
-                    node_plugin='velodyne_driver::VelodyneDriver',
-                    node_name='velodyne_driver_node',
+                    plugin='velodyne_driver::VelodyneDriver',
+                    name='velodyne_driver_node',
                     parameters=[driver_params]),
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Convert',
-                    node_name='velodyne_convert_node',
+                    plugin='velodyne_pointcloud::Convert',
+                    name='velodyne_convert_node',
                     parameters=[convert_params]),
                 ComposableNode(
                     package='velodyne_laserscan',
-                    node_plugin='velodyne_laserscan::VelodyneLaserScan',
-                    node_name='velodyne_laserscan_node',
+                    plugin='velodyne_laserscan::VelodyneLaserScan',
+                    name='velodyne_laserscan_node',
                     parameters=[laserscan_params]),
             ],
             output='both',

--- a/velodyne/launch/velodyne-all-nodes-VLP32C-launch.py
+++ b/velodyne/launch/velodyne-all-nodes-VLP32C-launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
     driver_share_dir = ament_index_python.packages.get_package_share_directory('velodyne_driver')
     driver_params_file = os.path.join(driver_share_dir, 'config', 'VLP32C-velodyne_driver_node-params.yaml')
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
-                                                   node_executable='velodyne_driver_node',
+                                                   executable='velodyne_driver_node',
                                                    output='both',
                                                    parameters=[driver_params_file])
 
@@ -53,14 +53,14 @@ def generate_launch_description():
         convert_params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     convert_params['calibration'] = os.path.join(convert_share_dir, 'params', 'VeloView-VLP-32C.yaml')
     velodyne_convert_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                    node_executable='velodyne_convert_node',
+                                                    executable='velodyne_convert_node',
                                                     output='both',
                                                     parameters=[convert_params])
 
     laserscan_share_dir = ament_index_python.packages.get_package_share_directory('velodyne_laserscan')
     laserscan_params_file = os.path.join(laserscan_share_dir, 'config', 'default-velodyne_laserscan_node-params.yaml')
     velodyne_laserscan_node = launch_ros.actions.Node(package='velodyne_laserscan',
-                                                      node_executable='velodyne_laserscan_node',
+                                                      executable='velodyne_laserscan_node',
                                                       output='both',
                                                       parameters=[laserscan_params_file])
 

--- a/velodyne_driver/launch/velodyne_driver_node-VLP16-composed-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP16-composed-launch.py
@@ -51,15 +51,15 @@ def generate_launch_description():
     with open(param_config, 'r') as f:
         params = yaml.safe_load(f)['velodyne_driver_node']['ros__parameters']
     container = ComposableNodeContainer(
-            node_name='velodyne_driver_container',
-            node_namespace='',
+            name='velodyne_driver_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_driver',
-                    node_plugin='velodyne_driver::VelodyneDriver',
-                    node_name='velodyne_driver_node',
+                    plugin='velodyne_driver::VelodyneDriver',
+                    name='velodyne_driver_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_driver/launch/velodyne_driver_node-VLP16-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP16-launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
         'config')
     params = os.path.join(config_directory, 'VLP16-velodyne_driver_node-params.yaml')
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
-                                                   node_executable='velodyne_driver_node',
+                                                   executable='velodyne_driver_node',
                                                    output='both',
                                                    parameters=[params])
 

--- a/velodyne_driver/launch/velodyne_driver_node-VLP32C-composed-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP32C-composed-launch.py
@@ -51,15 +51,15 @@ def generate_launch_description():
     with open(param_config, 'r') as f:
         params = yaml.safe_load(f)['velodyne_driver_node']['ros__parameters']
     container = ComposableNodeContainer(
-            node_name='velodyne_driver_container',
-            node_namespace='',
+            name='velodyne_driver_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_driver',
-                    node_plugin='velodyne_driver::VelodyneDriver',
-                    node_name='velodyne_driver_node',
+                    plugin='velodyne_driver::VelodyneDriver',
+                    name='velodyne_driver_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_driver/launch/velodyne_driver_node-VLP32C-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP32C-launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
         'config')
     params = os.path.join(config_directory, 'VLP32C-velodyne_driver_node-params.yaml')
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
-                                                   node_executable='velodyne_driver_node',
+                                                   executable='velodyne_driver_node',
                                                    output='both',
                                                    parameters=[params])
 

--- a/velodyne_laserscan/launch/velodyne_laserscan_node-composed-launch.py
+++ b/velodyne_laserscan/launch/velodyne_laserscan_node-composed-launch.py
@@ -49,15 +49,15 @@ def generate_launch_description():
     with open(params_file, 'r') as f:
         params = yaml.safe_load(f)['velodyne_laserscan_node']['ros__parameters']
     container = ComposableNodeContainer(
-            node_name='velodyne_laserscan_container',
-            node_namespace='',
+            name='velodyne_laserscan_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_laserscan',
-                    node_plugin='velodyne_laserscan::VelodyneLaserScan',
-                    node_name='velodyne_laserscan_node',
+                    plugin='velodyne_laserscan::VelodyneLaserScan',
+                    name='velodyne_laserscan_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_laserscan/launch/velodyne_laserscan_node-launch.py
+++ b/velodyne_laserscan/launch/velodyne_laserscan_node-launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
     share_dir = ament_index_python.packages.get_package_share_directory('velodyne_laserscan')
     params_file = os.path.join(share_dir, 'config', 'default-velodyne_laserscan_node-params.yaml')
     velodyne_laserscan_node = launch_ros.actions.Node(package='velodyne_laserscan',
-                                                      node_executable='velodyne_laserscan_node',
+                                                      executable='velodyne_laserscan_node',
                                                       output='both',
                                                       parameters=[params_file])
 

--- a/velodyne_pointcloud/launch/velodyne_convert_node-VLP16-composed-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_convert_node-VLP16-composed-launch.py
@@ -50,15 +50,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VLP16db.yaml')
     container = ComposableNodeContainer(
-            node_name='velodyne_pointcloud_convert_container',
-            node_namespace='',
+            name='velodyne_pointcloud_convert_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Convert',
-                    node_name='velodyne_convert_node',
+                    plugin='velodyne_pointcloud::Convert',
+                    name='velodyne_convert_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_pointcloud/launch/velodyne_convert_node-VLP16-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_convert_node-VLP16-launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VLP16db.yaml')
     velodyne_convert_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                    node_executable='velodyne_convert_node',
+                                                    executable='velodyne_convert_node',
                                                     output='both',
                                                     parameters=[params])
 

--- a/velodyne_pointcloud/launch/velodyne_convert_node-VLP32C-composed-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_convert_node-VLP32C-composed-launch.py
@@ -50,15 +50,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VeloView-VLP-32C.yaml')
     container = ComposableNodeContainer(
-            node_name='velodyne_pointcloud_convert_container',
-            node_namespace='',
+            name='velodyne_pointcloud_convert_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Convert',
-                    node_name='velodyne_convert_node',
+                    plugin='velodyne_pointcloud::Convert',
+                    name='velodyne_convert_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_pointcloud/launch/velodyne_convert_node-VLP32C-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_convert_node-VLP32C-launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_convert_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VeloView-VLP-32C.yaml')
     velodyne_convert_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                    node_executable='velodyne_convert_node',
+                                                    executable='velodyne_convert_node',
                                                     output='both',
                                                     parameters=[params])
 

--- a/velodyne_pointcloud/launch/velodyne_transform_node-VLP16-composed-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_transform_node-VLP16-composed-launch.py
@@ -50,15 +50,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_transform_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VLP16db.yaml')
     container = ComposableNodeContainer(
-            node_name='velodyne_pointcloud_transform_container',
-            node_namespace='',
+            name='velodyne_pointcloud_transform_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Transform',
-                    node_name='velodyne_transform_node',
+                    plugin='velodyne_pointcloud::Transform',
+                    name='velodyne_transform_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_pointcloud/launch/velodyne_transform_node-VLP16-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_transform_node-VLP16-launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_transform_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VLP16db.yaml')
     velodyne_transform_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                      node_executable='velodyne_transform_node',
+                                                      executable='velodyne_transform_node',
                                                       output='both',
                                                       parameters=[params])
 

--- a/velodyne_pointcloud/launch/velodyne_transform_node-VLP32C-composed-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_transform_node-VLP32C-composed-launch.py
@@ -50,15 +50,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_transform_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VeloView-VLP-32C.yaml')
     container = ComposableNodeContainer(
-            node_name='velodyne_pointcloud_transform_container',
-            node_namespace='',
+            name='velodyne_pointcloud_transform_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='velodyne_pointcloud',
-                    node_plugin='velodyne_pointcloud::Transform',
-                    node_name='velodyne_transform_node',
+                    plugin='velodyne_pointcloud::Transform',
+                    name='velodyne_transform_node',
                     parameters=[params]),
             ],
             output='both',

--- a/velodyne_pointcloud/launch/velodyne_transform_node-VLP32C-launch.py
+++ b/velodyne_pointcloud/launch/velodyne_transform_node-VLP32C-launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         params = yaml.safe_load(f)['velodyne_transform_node']['ros__parameters']
     params['calibration'] = os.path.join(share_dir, 'params', 'VeloView-VLP-32C.yaml')
     velodyne_transform_node = launch_ros.actions.Node(package='velodyne_pointcloud',
-                                                      node_executable='velodyne_transform_node',
+                                                      executable='velodyne_transform_node',
                                                       output='both',
                                                       parameters=[params])
 


### PR DESCRIPTION
Some of the argument names are deprecated in Foxy and do not work in Galactic. Eg. `node_executable` should now be just `executable`. After some testing with a VLP-16 on ROS2 Galactic the updated launch files worked as expected and the nodes were launched.