### PR TITLE
Link against yaml-cpp

### DIFF
--- a/velodyne_pointcloud/src/lib/CMakeLists.txt
+++ b/velodyne_pointcloud/src/lib/CMakeLists.txt
@@ -11,6 +11,9 @@ ament_target_dependencies(velodyne_rawdata
   velodyne_msgs
 )
 
+target_link_libraries(velodyne_rawdata
+        ${YAML_CPP_LIBRARIES})
+
 add_library(velodyne_cloud_types SHARED
   pointcloudXYZIR.cpp
   organized_cloudXYZIR.cpp


### PR DESCRIPTION
On MacOS building the ros2 branch fails with the following error:

```
--- stderr: velodyne_pointcloud
Undefined symbols for architecture x86_64:
  "YAML::InvalidNode::~InvalidNode()", referenced from:
      YAML::Node const YAML::Node::operator[]<char [9]>(char const (&) [9]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [15]>(char const (&) [15]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [16]>(char const (&) [16]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [28]>(char const (&) [28]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [18]>(char const (&) [18]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [23]>(char const (&) [23]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [24]>(char const (&) [24]) const in calibration.cpp.o
      ...
  "YAML::BadSubscript::~BadSubscript()", referenced from:
      YAML::detail::node* YAML::detail::node_data::get<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<YAML::detail::memory_holder>) const in calibration.cpp.o
      YAML::detail::node* YAML::detail::node_data::get<int>(int const&, std::__1::shared_ptr<YAML::detail::memory_holder>) const in calibration.cpp.o
  "YAML::BadConversion::~BadConversion()", referenced from:
      YAML::TypedBadConversion<int>::~TypedBadConversion() in calibration.cpp.o
      YAML::TypedBadConversion<float>::~TypedBadConversion() in calibration.cpp.o
      YAML::TypedBadConversion<bool>::~TypedBadConversion() in calibration.cpp.o
  "YAML::detail::memory_holder::merge(YAML::detail::memory_holder&)", referenced from:
      YAML::Node::AssignNode(YAML::Node const&) in calibration.cpp.o
  "YAML::detail::memory::create_node()", referenced from:
      YAML::detail::memory_holder::create_node() in calibration.cpp.o
  "YAML::detail::node_data::empty_scalar()", referenced from:
      YAML::Node::Scalar() const in calibration.cpp.o
  "YAML::detail::node_data::mark_defined()", referenced from:
      YAML::detail::node_ref::mark_defined() in calibration.cpp.o
  "YAML::detail::node_data::set_null()", referenced from:
      YAML::detail::node_ref::set_null() in calibration.cpp.o
  "YAML::convert<bool>::decode(YAML::Node const&, bool&)", referenced from:
      YAML::as_if<bool, void>::operator()() const in calibration.cpp.o
  "YAML::LoadFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      velodyne_pointcloud::Calibration::Calibration(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in calibration.cpp.o
  "typeinfo for YAML::InvalidNode", referenced from:
      YAML::Node const YAML::Node::operator[]<char [9]>(char const (&) [9]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [15]>(char const (&) [15]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [16]>(char const (&) [16]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [28]>(char const (&) [28]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [18]>(char const (&) [18]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [23]>(char const (&) [23]) const in calibration.cpp.o
      YAML::Node const YAML::Node::operator[]<char [24]>(char const (&) [24]) const in calibration.cpp.o
      ...
  "typeinfo for YAML::BadSubscript", referenced from:
      YAML::detail::node* YAML::detail::node_data::get<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::shared_ptr<YAML::detail::memory_holder>) const in calibration.cpp.o
      YAML::detail::node* YAML::detail::node_data::get<int>(int const&, std::__1::shared_ptr<YAML::detail::memory_holder>) const in calibration.cpp.o
  "typeinfo for YAML::BadConversion", referenced from:
      typeinfo for YAML::TypedBadConversion<int> in calibration.cpp.o
      typeinfo for YAML::TypedBadConversion<float> in calibration.cpp.o
      typeinfo for YAML::TypedBadConversion<bool> in calibration.cpp.o
  "typeinfo for YAML::Exception", referenced from:
      GCC_except_table26 in calibration.cpp.o
  "vtable for YAML::InvalidNode", referenced from:
      YAML::InvalidNode::InvalidNode(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >) in calibration.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for YAML::BadSubscript", referenced from:
      YAML::BadSubscript::BadSubscript<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in calibration.cpp.o
      YAML::BadSubscript::BadSubscript<int>(int const&) in calibration.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for YAML::BadConversion", referenced from:
      YAML::BadConversion::BadConversion(YAML::Mark const&) in calibration.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for YAML::RepresentationException", referenced from:
      YAML::RepresentationException::RepresentationException(YAML::Mark const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in calibration.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for YAML::Exception", referenced from:
      YAML::Exception::Exception(YAML::Mark const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in calibration.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/lib/libvelodyne_rawdata.dylib] Error 1
make[1]: *** [src/lib/CMakeFiles/velodyne_rawdata.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

This is resolved by linking velodyne_rawdata against yaml-cpp as it is also the case in the master branch.