### PR TITLE
Fix non-responsive node on packet timeout

### DIFF
--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -219,7 +219,7 @@ bool VelodyneDriver::poll(void)
     {
       while(true)
       {
-        int rc = input_->getPacket(&tmp_packet, config_.time_offset);        
+        int rc = input_->getPacket(&tmp_packet, config_.time_offset);
         if (rc == 1) break;       // got a full packet?
         if (rc < 0) return false; // end of file reached?
         if (rc == 0) continue;    //timeout?

--- a/velodyne_driver/src/driver/driver.cc
+++ b/velodyne_driver/src/driver/driver.cc
@@ -219,9 +219,10 @@ bool VelodyneDriver::poll(void)
     {
       while(true)
       {
-        int rc = input_->getPacket(&tmp_packet, config_.time_offset);
-        if (rc == 0) break;       // got a full packet?
+        int rc = input_->getPacket(&tmp_packet, config_.time_offset);        
+        if (rc == 1) break;       // got a full packet?
         if (rc < 0) return false; // end of file reached?
+        if (rc == 0) continue;    //timeout?
       }
       scan->packets.push_back(tmp_packet);
 
@@ -255,8 +256,9 @@ bool VelodyneDriver::poll(void)
         {
           // keep reading until full packet received
           int rc = input_->getPacket(&scan->packets[i], config_.time_offset);
-          if (rc == 0) break;       // got a full packet?
+          if (rc == 1) break;       // got a full packet?
           if (rc < 0) return false; // end of file reached?
+          if (rc == 0) continue;    //timeout?
         }
     }
   }

--- a/velodyne_driver/src/lib/input.cc
+++ b/velodyne_driver/src/lib/input.cc
@@ -189,7 +189,7 @@ namespace velodyne_driver
             if (retval == 0)            // poll() timeout?
               {
                 ROS_WARN("Velodyne poll() timeout");
-                return -1;
+                return 0;
               }
             if ((fds[0].revents & POLLERR)
                 || (fds[0].revents & POLLHUP)
@@ -243,7 +243,7 @@ namespace velodyne_driver
       pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]));
     }
 
-    return 0;
+    return 1;
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -339,7 +339,7 @@ namespace velodyne_driver
               pkt->stamp = rosTimeFromGpsTimestamp(&(pkt->data[1200]), header);
             }
             empty_ = false;
-            return 0;                   // success
+            return 1;                   // success
           }
 
         if (empty_)                 // no data in file?


### PR DESCRIPTION
Commits d016fcc336a0c4e49423c966aa3acc0477848644 and 15771a42cf91ffaa946846174c639edf1056b693 in combination turned packet timeouts into an error that stops the node from responding. This patch restores the original behavior.

Changed getPacket() to return 0 on timeout and 1 on success. 
Updated VelodyneDriver::poll() accordingly.