### PR TITLE
[velodyne_pointcloud] add_two_pt scripts

### DIFF
--- a/velodyne_pointcloud/params/64e_s2.1-sztaki.yaml
+++ b/velodyne_pointcloud/params/64e_s2.1-sztaki.yaml
@@ -1,246 +1,753 @@
-lasers:
-- {dist_correction: 1.5195264000000002, dist_correction_x: 1.5500304, dist_correction_y: 1.5231381,
-  focal_distance: 12.0, focal_slope: 1.4, horiz_offset_correction: 0.025999999, laser_id: 0,
-  max_intensity: 235.0, min_intensity: 30.0, rot_correction: -0.1248942899601548,
-  vert_correction: -0.15304134919741974, vert_offset_correction: 0.19548199}
-- {dist_correction: 1.5145139, dist_correction_x: 1.5256960000000002, dist_correction_y: 1.5491043,
-  focal_distance: 5.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 1,
-  min_intensity: 40.0, rot_correction: -0.06924466398252106, vert_correction: -0.1458455539136526,
-  vert_offset_correction: 0.19601112}
-- {dist_correction: 1.4963768, dist_correction_x: 1.5571011, dist_correction_y: 1.5456782999999998,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 2, min_intensity: 60.0, rot_correction: 0.0824016906676694, vert_correction: 0.04339494149708345,
-  vert_offset_correction: 0.20969539999999998}
-- {dist_correction: 1.3771207, dist_correction_x: 1.4103835, dist_correction_y: 1.4343457000000002,
-  focal_distance: 9.5, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 3,
-  min_intensity: 20.0, rot_correction: 0.137808349360133, vert_correction: 0.05196082373432465,
-  vert_offset_correction: 0.21031273}
-- {dist_correction: 1.2947885, dist_correction_x: 1.3720455999999999, dist_correction_y: 1.4025244000000001,
-  focal_distance: 10.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 4,
-  min_intensity: 50.0, rot_correction: -0.011199603626188263, vert_correction: -0.1358262679404349,
-  vert_offset_correction: 0.19674603999999998}
-- {dist_correction: 1.4395787000000002, dist_correction_x: 1.4801956, dist_correction_y: 1.5074649,
-  focal_distance: 7.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 5,
-  min_intensity: 30.0, rot_correction: 0.045795414990398894, vert_correction: -0.12678532627942263,
-  vert_offset_correction: 0.19740747}
-- {dist_correction: 1.3618773, dist_correction_x: 1.4004077000000001, dist_correction_y: 1.3900876,
-  focal_distance: 5.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 6,
-  min_intensity: 65.0, rot_correction: -0.031646046452444135, vert_correction: -0.1895564226946273,
-  vert_offset_correction: 0.19277746}
-- {dist_correction: 1.5325716, dist_correction_x: 1.5337143, dist_correction_y: 1.5452948000000002,
-  focal_distance: 6.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 7,
-  min_intensity: 10.0, rot_correction: 0.023408326257150665, vert_correction: -0.18086723120040343,
-  vert_offset_correction: 0.19342419}
-- {dist_correction: 1.3743323, dist_correction_x: 1.4474606, dist_correction_y: 1.4533472,
-  focal_distance: 6.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 8,
-  min_intensity: 30.0, rot_correction: 0.10065885915180103, vert_correction: -0.11973897655818674,
-  vert_offset_correction: 0.19792192}
-- {dist_correction: 1.4969112000000002, dist_correction_x: 1.4754176, dist_correction_y: 1.4888799000000001,
-  focal_distance: 5.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 9,
-  min_intensity: 10.0, rot_correction: 0.15996423607269877, vert_correction: -0.10924820210484752,
-  vert_offset_correction: 0.19868624000000001}
-- {dist_correction: 1.434263, dist_correction_x: 1.4957901000000002, dist_correction_y: 1.5191892999999999,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 10, min_intensity: 35.0, rot_correction: 0.08313316164783874, vert_correction: -0.17135657256846043,
-  vert_offset_correction: 0.19412970999999998}
-- {dist_correction: 1.5500841, dist_correction_x: 1.542697, dist_correction_y: 1.5716737,
-  focal_distance: 8.0, focal_slope: 1.2, horiz_offset_correction: -0.025999999, laser_id: 11,
-  min_intensity: 30.0, rot_correction: 0.13862572370075624, vert_correction: -0.1630088948849621,
-  vert_offset_correction: 0.19474705}
-- {dist_correction: 1.3725992, dist_correction_x: 1.4353555, dist_correction_y: 1.3932405,
-  focal_distance: 11.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 12,
-  min_intensity: 50.0, rot_correction: -0.1255805045528199, vert_correction: -0.04526314018308893,
-  vert_offset_correction: 0.20331627000000002}
-- {dist_correction: 1.3111591000000002, dist_correction_x: 1.3470857, dist_correction_y: 1.3652054000000002,
-  focal_distance: 6.0, focal_slope: 0.69999999, horiz_offset_correction: -0.025999999,
-  laser_id: 13, min_intensity: 30.0, rot_correction: -0.06716508498014805, vert_correction: -0.03587557613263058,
-  vert_offset_correction: 0.20399239000000002}
-- {dist_correction: 1.5360803, dist_correction_x: 1.5528035, dist_correction_y: 1.5666801000000001,
-  focal_distance: 8.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 14,
-  min_intensity: 20.0, rot_correction: -0.14578889529014513, vert_correction: -0.09893566067472198,
-  vert_offset_correction: 0.19943586}
-- {dist_correction: 1.4755448999999998, dist_correction_x: 1.5032428, dist_correction_y: 1.5326752,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 15, min_intensity: 30.0, rot_correction: -0.08892898296002069, vert_correction: -0.09062974348423608,
-  vert_offset_correction: 0.20003851}
-- {dist_correction: 1.4410587000000001, dist_correction_x: 1.4870845, dist_correction_y: 1.4627965,
-  focal_distance: 18.0, focal_slope: 0.5, horiz_offset_correction: 0.025999999, laser_id: 16,
-  min_intensity: 40.0, rot_correction: -0.013006177528832626, vert_correction: -0.02770725895504266,
-  vert_offset_correction: 0.20458033}
-- {dist_correction: 1.4434521, dist_correction_x: 1.4897508, dist_correction_y: 1.4791382,
-  focal_distance: 11.0, focal_slope: 0.80000001, horiz_offset_correction: -0.025999999,
-  laser_id: 17, min_intensity: 55.0, rot_correction: 0.04596628970548614, vert_correction: -0.02014825541794774,
-  vert_offset_correction: 0.20512417}
-- {dist_correction: 1.3243448000000002, dist_correction_x: 1.3816666000000002, dist_correction_y: 1.3647719,
-  focal_distance: 12.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 18,
-  min_intensity: 10.0, rot_correction: -0.03237303019110658, vert_correction: -0.08210824496987311,
-  vert_offset_correction: 0.20065581999999998}
-- {dist_correction: 1.4565853999999998, dist_correction_x: 1.4340645, dist_correction_y: 1.4550516,
-  focal_distance: 20.0, focal_slope: 0.69999999, horiz_offset_correction: -0.025999999,
-  laser_id: 19, min_intensity: 30.0, rot_correction: 0.02431275238487562, vert_correction: -0.0727614640280461,
-  vert_offset_correction: 0.20133196000000003}
-- {dist_correction: 1.3313776, dist_correction_x: 1.3819601000000001, dist_correction_y: 1.3847791,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 20, min_intensity: 45.0, rot_correction: 0.10029393174916004, vert_correction: -0.009929893699589059,
-  vert_offset_correction: 0.20585909000000002}
-- {dist_correction: 1.3787535, dist_correction_x: 1.3978789, dist_correction_y: 1.4257806,
-  focal_distance: 10.0, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 21,
-  min_intensity: 35.0, rot_correction: 0.15867894419560363, vert_correction: -0.0037977317325845416,
-  vert_offset_correction: 0.20630005}
-- {dist_correction: 1.3419412, dist_correction_x: 1.4059189, dist_correction_y: 1.4113303,
-  focal_distance: 11.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 22,
-  min_intensity: 40.0, rot_correction: 0.08044522544540282, vert_correction: -0.06482699129962814,
-  vert_offset_correction: 0.20190518999999998}
-- {dist_correction: 1.4338304, dist_correction_x: 1.4212059, dist_correction_y: 1.4900565000000001,
-  focal_distance: 11.0, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 23,
-  min_intensity: 55.0, rot_correction: 0.13867708175932542, vert_correction: -0.05566171063737453,
-  vert_offset_correction: 0.20256662}
-- {dist_correction: 1.4930911, dist_correction_x: 1.5572188, dist_correction_y: 1.5182672,
-  focal_distance: 5.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 24,
-  min_intensity: 25.0, rot_correction: -0.12505298227706313, vert_correction: 0.06113007152996804,
-  vert_offset_correction: 0.21097416}
-- {dist_correction: 1.4367653000000002, dist_correction_x: 1.4614236, dist_correction_y: 1.4587589,
-  focal_distance: 3.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 25,
-  min_intensity: 50.0, rot_correction: -0.06814826559971075, vert_correction: 0.06988221181432357,
-  vert_offset_correction: 0.21160620000000002}
-- {dist_correction: 1.5279892000000002, dist_correction_x: 1.5686107999999999, dist_correction_y: 1.55737,
-  focal_distance: 7.5, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 26,
-  min_intensity: 30.0, rot_correction: -0.14531660046790917, vert_correction: 0.00887576771486082,
-  vert_offset_correction: 0.20721134}
-- {dist_correction: 1.5077638, dist_correction_x: 1.5453738000000001, dist_correction_y: 1.5483368,
-  focal_distance: 4.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 27, min_intensity: 30.0, rot_correction: -0.08904354811745085, vert_correction: 0.017050959569839413,
-  vert_offset_correction: 0.20779928000000003}
-- {dist_correction: 1.3627797000000001, dist_correction_x: 1.4232985, dist_correction_y: 1.4116524000000001,
-  focal_distance: 4.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 28,
-  min_intensity: 50.0, rot_correction: -0.012061568860271928, vert_correction: 0.07842048992411524,
-  vert_offset_correction: 0.21222351}
-- {dist_correction: 1.3749608, dist_correction_x: 1.4045798, dist_correction_y: 1.4006630999999998,
-  focal_distance: 4.0, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 29,
-  min_intensity: 40.0, rot_correction: 0.043892943273872005, vert_correction: 0.08674443287511571,
-  vert_offset_correction: 0.21282616000000001}
-- {dist_correction: 1.2940709000000001, dist_correction_x: 1.392794, dist_correction_y: 1.3225565000000001,
-  focal_distance: 8.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 30, min_intensity: 90.0, rot_correction: -0.033068739374902546, vert_correction: 0.02522388232225749,
-  vert_offset_correction: 0.20838722}
-- {dist_correction: 1.3907666, dist_correction_x: 1.4365166, dist_correction_y: 1.4501437000000001,
-  focal_distance: 9.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 31,
-  min_intensity: 5.0, rot_correction: 0.025535290948715324, vert_correction: 0.034414332377654115,
-  vert_offset_correction: 0.20904865}
-- {dist_correction: 1.3461819, dist_correction_x: 1.3678523000000002, dist_correction_y: 1.3552880999999999,
-  focal_distance: 11.0, focal_slope: 1.5, horiz_offset_correction: 0.025999999, laser_id: 32,
-  min_intensity: 45.0, rot_correction: -0.13309965698710405, vert_correction: -0.39666389380060213,
-  vert_offset_correction: 0.10812234999999999}
-- {dist_correction: 1.2487466, dist_correction_x: 1.2929747, dist_correction_y: 1.3438803,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 33, min_intensity: 35.0, rot_correction: -0.07241159183553281, vert_correction: -0.39021216204755743,
-  vert_offset_correction: 0.10859233}
-- {dist_correction: 1.5016498000000003, dist_correction_x: 1.5384890999999998, dist_correction_y: 1.5506186,
-  focal_distance: 4.5, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 34,
-  min_intensity: 20.0, rot_correction: 0.08292710807634829, vert_correction: -0.2010672181773803,
-  vert_offset_correction: 0.12148494}
-- {dist_correction: 1.2495708, dist_correction_x: 1.2891127, dist_correction_y: 1.2943669,
-  focal_distance: 11.0, focal_slope: 1.3, horiz_offset_correction: -0.025999999, laser_id: 35,
-  min_intensity: 25.0, rot_correction: 0.14006506182829093, vert_correction: -0.19103771853737994,
-  vert_offset_correction: 0.12213274}
-- {dist_correction: 1.2674536, dist_correction_x: 1.3298663, dist_correction_y: 1.3577469,
-  focal_distance: 6.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 36, min_intensity: 35.0, rot_correction: -0.012004346320883118, vert_correction: -0.3819670695815035,
-  vert_offset_correction: 0.10918932}
-- {dist_correction: 1.2481956, dist_correction_x: 1.28627, dist_correction_y: 1.29235,
-  focal_distance: 14.5, focal_slope: 1.5, horiz_offset_correction: -0.025999999, laser_id: 37,
-  min_intensity: 30.0, rot_correction: 0.04832190474636683, vert_correction: -0.3718940414299584,
-  vert_offset_correction: 0.10991334}
-- {dist_correction: 1.4516722, dist_correction_x: 1.4842308, dist_correction_y: 1.4868384000000001,
-  focal_distance: 4.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 38,
-  min_intensity: 55.0, rot_correction: -0.03583078923869515, vert_correction: -0.4336284663746853,
-  vert_offset_correction: 0.1053787}
-- {dist_correction: 1.3843003999999999, dist_correction_x: 1.4010727, dist_correction_y: 1.4332015999999999,
-  focal_distance: 6.5, focal_slope: 1.3, horiz_offset_correction: -0.025999999, laser_id: 39,
-  min_intensity: 40.0, rot_correction: 0.026883486237381612, vert_correction: -0.4261966798867682,
-  vert_offset_correction: 0.10593759000000001}
-- {dist_correction: 1.244738, dist_correction_x: 1.3131859000000001, dist_correction_y: 1.354245,
-  focal_distance: 6.5, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 40,
-  min_intensity: 25.0, rot_correction: 0.1076316048478218, vert_correction: -0.3640637439139335,
-  vert_offset_correction: 0.11047223}
-- {dist_correction: 1.3284543, dist_correction_x: 1.3295518000000002, dist_correction_y: 1.3809489,
-  focal_distance: 12.5, focal_slope: 1.7, horiz_offset_correction: -0.025999999, laser_id: 41,
-  min_intensity: 50.0, rot_correction: 0.1679293847080498, vert_correction: -0.3511493721000192,
-  vert_offset_correction: 0.11138678}
-- {dist_correction: 1.4055542, dist_correction_x: 1.4426663, dist_correction_y: 1.430847,
-  focal_distance: 1.5, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 42,
-  min_intensity: 10.0, rot_correction: 0.0861156692854385, vert_correction: -0.4163231777753111,
-  vert_offset_correction: 0.10667431000000001}
-- {dist_correction: 1.3529747, dist_correction_x: 1.3834917999999998, dist_correction_y: 1.4029074,
-  focal_distance: 6.0, focal_slope: 1.2, horiz_offset_correction: -0.025999999, laser_id: 43,
-  min_intensity: 35.0, rot_correction: 0.15024020221305323, vert_correction: -0.4046365927302973,
-  vert_offset_correction: 0.10753805}
-- {dist_correction: 1.2407380000000001, dist_correction_x: 1.3171521000000002, dist_correction_y: 1.2836400000000001,
-  focal_distance: 15.0, focal_slope: 1.6, horiz_offset_correction: 0.025999999, laser_id: 44,
-  max_intensity: 220.0, rot_correction: -0.12998527227122358, vert_correction: -0.28892197890806653,
-  vert_offset_correction: 0.11568009}
-- {dist_correction: 1.5288051999999999, dist_correction_x: 1.5904514, dist_correction_y: 1.6288455,
-  focal_distance: 10.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 45, rot_correction: -0.07009281894983248, vert_correction: -0.28120381879648226,
-  vert_offset_correction: 0.11620087}
-- {dist_correction: 1.5423979, dist_correction_x: 1.5919412, dist_correction_y: 1.610177,
-  focal_distance: 13.0, focal_slope: 1.7, horiz_offset_correction: 0.025999999, laser_id: 46,
-  rot_correction: -0.1533711640661691, vert_correction: -0.34156398894148127, vert_offset_correction: 0.11205999}
-- {dist_correction: 1.3086252999999999, dist_correction_x: 1.3737134, dist_correction_y: 1.4177727,
-  focal_distance: 5.5, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 47, rot_correction: -0.0927890927600715, vert_correction: -0.3348332488542128,
-  vert_offset_correction: 0.11252997}
-- {dist_correction: 1.3405330000000002, dist_correction_x: 1.4512436, dist_correction_y: 1.4471467999999998,
-  focal_distance: 13.5, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 48,
-  rot_correction: -0.012004348415278218, vert_correction: -0.2738300470529015, vert_offset_correction: 0.11669625}
-- {dist_correction: 1.2994545, dist_correction_x: 1.3971343999999999, dist_correction_y: 1.36849,
-  focal_distance: 14.0, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 49,
-  rot_correction: 0.047471358677980184, vert_correction: -0.2649030020882158, vert_offset_correction: 0.11729325}
-- {dist_correction: 1.4499762999999999, dist_correction_x: 1.5111346, dist_correction_y: 1.542395,
-  focal_distance: 13.0, focal_slope: 1.2, horiz_offset_correction: 0.025999999, laser_id: 50,
-  rot_correction: -0.03378136079915033, vert_correction: -0.32678797913421975, vert_offset_correction: 0.11308886}
-- {dist_correction: 1.3516956, dist_correction_x: 1.4231836999999998, dist_correction_y: 1.4301146,
-  focal_distance: 13.0, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 51,
-  rot_correction: 0.025334358173250228, vert_correction: -0.3179609589889659, vert_offset_correction: 0.11369856}
-- {dist_correction: 1.2374236, dist_correction_x: 1.308008, dist_correction_y: 1.3549429000000002,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: 0.025999999,
-  laser_id: 52, rot_correction: 0.10481975724981128, vert_correction: -0.25478428121685354,
-  vert_offset_correction: 0.11796646000000001}
-- {dist_correction: 1.3730562000000002, dist_correction_x: 1.403678, dist_correction_y: 1.4347415000000001,
-  focal_distance: 13.0, focal_slope: 1.4, horiz_offset_correction: -0.025999999, laser_id: 53,
-  rot_correction: 0.16311715242247551, vert_correction: -0.24576616497179882, vert_offset_correction: 0.11856346000000001}
-- {dist_correction: 1.4445888, dist_correction_x: 1.5025624, dist_correction_y: 1.5189749000000001,
-  focal_distance: 10.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 54,
-  rot_correction: 0.08384971878954978, vert_correction: -0.31000962288931516, vert_offset_correction: 0.11424474999999999}
-- {dist_correction: 1.3861449, dist_correction_x: 1.4228815000000001, dist_correction_y: 1.4620186000000002,
-  focal_distance: 15.0, focal_slope: 1.6, horiz_offset_correction: -0.025999999, laser_id: 55,
-  rot_correction: 0.14374613400834294, vert_correction: -0.2986601307360315, vert_offset_correction: 0.11501958000000001}
-- {dist_correction: 1.4635341, dist_correction_x: 1.5232283000000002, dist_correction_y: 1.5063837000000002,
-  focal_distance: 13.0, focal_slope: 1.3, horiz_offset_correction: 0.025999999, laser_id: 56,
-  rot_correction: -0.12741928396895377, vert_correction: -0.18393445537456576, vert_offset_correction: 0.12259002000000001}
-- {dist_correction: 1.3715826000000002, dist_correction_x: 1.4186972, dist_correction_y: 1.4328435,
-  focal_distance: 3.5, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 57,
-  rot_correction: -0.06853129555735342, vert_correction: -0.1744342722087932, vert_offset_correction: 0.12319972}
-- {dist_correction: 1.4644831999999999, dist_correction_x: 1.5095984000000002, dist_correction_y: 1.5149265,
-  focal_distance: 11.0, focal_slope: 1.4, horiz_offset_correction: 0.025999999, laser_id: 58,
-  rot_correction: -0.1497316045423758, vert_correction: -0.23400086557751998, vert_offset_correction: 0.11933828}
-- {dist_correction: 1.3074548, dist_correction_x: 1.3521214000000001, dist_correction_y: 1.3830151000000002,
-  focal_distance: 5.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 59, rot_correction: -0.08973572126418226, vert_correction: -0.22644383426247983,
-  vert_offset_correction: 0.11983367}
-- {dist_correction: 1.4378391, dist_correction_x: 1.4799687000000001, dist_correction_y: 1.4889211,
-  focal_distance: 5.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 60,
-  rot_correction: -0.011751946229237658, vert_correction: -0.1678843098347878, vert_offset_correction: 0.12361888}
-- {dist_correction: 1.3585466, dist_correction_x: 1.4135242, dist_correction_y: 1.4170488,
-  focal_distance: 2.0, focal_slope: 0.89999998, horiz_offset_correction: -0.025999999,
-  laser_id: 61, rot_correction: 0.04489272721060892, vert_correction: -0.158331168143522,
-  vert_offset_correction: 0.12422858}
-- {dist_correction: 1.4478067, dist_correction_x: 1.5442529, dist_correction_y: 1.5512207,
-  focal_distance: 10.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 62,
-  rot_correction: -0.0340408982402389, vert_correction: -0.21671681763514258, vert_offset_correction: 0.12046877}
-- {dist_correction: 1.4329738, dist_correction_x: 1.4817114, dist_correction_y: 1.4954124,
-  focal_distance: 9.0, focal_slope: 0.80000001, horiz_offset_correction: -0.025999999,
-  laser_id: 63, rot_correction: 0.024857907722065305, vert_correction: -0.2106649408137298,
-  vert_offset_correction: 0.12086253}
-num_lasers: 64
 distance_resolution: 0.002
+lasers:
+- dist_correction: 1.5195264000000002
+  dist_correction_x: 1.5500304
+  dist_correction_y: 1.5231381
+  focal_distance: 12.0
+  focal_slope: 1.4
+  horiz_offset_correction: 0.025999999
+  laser_id: 0
+  max_intensity: 235
+  min_intensity: 30
+  rot_correction: -0.1248942899601548
+  two_pt_correction_available: true
+  vert_correction: -0.15304134919741974
+  vert_offset_correction: 0.19548199
+- dist_correction: 1.5145139
+  dist_correction_x: 1.5256960000000002
+  dist_correction_y: 1.5491043
+  focal_distance: 5.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 1
+  min_intensity: 40
+  rot_correction: -0.06924466398252106
+  two_pt_correction_available: true
+  vert_correction: -0.1458455539136526
+  vert_offset_correction: 0.19601112
+- dist_correction: 1.4963768
+  dist_correction_x: 1.5571011
+  dist_correction_y: 1.5456782999999998
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 2
+  min_intensity: 60
+  rot_correction: 0.0824016906676694
+  two_pt_correction_available: true
+  vert_correction: 0.04339494149708345
+  vert_offset_correction: 0.20969539999999998
+- dist_correction: 1.3771207
+  dist_correction_x: 1.4103835
+  dist_correction_y: 1.4343457000000002
+  focal_distance: 9.5
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 3
+  min_intensity: 20
+  rot_correction: 0.137808349360133
+  two_pt_correction_available: true
+  vert_correction: 0.05196082373432465
+  vert_offset_correction: 0.21031273
+- dist_correction: 1.2947885
+  dist_correction_x: 1.3720455999999999
+  dist_correction_y: 1.4025244000000001
+  focal_distance: 10.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 4
+  min_intensity: 50
+  rot_correction: -0.011199603626188263
+  two_pt_correction_available: true
+  vert_correction: -0.1358262679404349
+  vert_offset_correction: 0.19674603999999998
+- dist_correction: 1.4395787000000002
+  dist_correction_x: 1.4801956
+  dist_correction_y: 1.5074649
+  focal_distance: 7.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 5
+  min_intensity: 30
+  rot_correction: 0.045795414990398894
+  two_pt_correction_available: true
+  vert_correction: -0.12678532627942263
+  vert_offset_correction: 0.19740747
+- dist_correction: 1.3618773
+  dist_correction_x: 1.4004077000000001
+  dist_correction_y: 1.3900876
+  focal_distance: 5.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 6
+  min_intensity: 65
+  rot_correction: -0.031646046452444135
+  two_pt_correction_available: true
+  vert_correction: -0.1895564226946273
+  vert_offset_correction: 0.19277746
+- dist_correction: 1.5325716
+  dist_correction_x: 1.5337143
+  dist_correction_y: 1.5452948000000002
+  focal_distance: 6.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 7
+  min_intensity: 10
+  rot_correction: 0.023408326257150665
+  two_pt_correction_available: true
+  vert_correction: -0.18086723120040343
+  vert_offset_correction: 0.19342419
+- dist_correction: 1.3743323
+  dist_correction_x: 1.4474606
+  dist_correction_y: 1.4533472
+  focal_distance: 6.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 8
+  min_intensity: 30
+  rot_correction: 0.10065885915180103
+  two_pt_correction_available: true
+  vert_correction: -0.11973897655818674
+  vert_offset_correction: 0.19792192
+- dist_correction: 1.4969112000000002
+  dist_correction_x: 1.4754176
+  dist_correction_y: 1.4888799000000001
+  focal_distance: 5.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 9
+  min_intensity: 10
+  rot_correction: 0.15996423607269877
+  two_pt_correction_available: true
+  vert_correction: -0.10924820210484752
+  vert_offset_correction: 0.19868624000000001
+- dist_correction: 1.434263
+  dist_correction_x: 1.4957901000000002
+  dist_correction_y: 1.5191892999999999
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 10
+  min_intensity: 35
+  rot_correction: 0.08313316164783874
+  two_pt_correction_available: true
+  vert_correction: -0.17135657256846043
+  vert_offset_correction: 0.19412970999999998
+- dist_correction: 1.5500841
+  dist_correction_x: 1.542697
+  dist_correction_y: 1.5716737
+  focal_distance: 8.0
+  focal_slope: 1.2
+  horiz_offset_correction: -0.025999999
+  laser_id: 11
+  min_intensity: 30
+  rot_correction: 0.13862572370075624
+  two_pt_correction_available: true
+  vert_correction: -0.1630088948849621
+  vert_offset_correction: 0.19474705
+- dist_correction: 1.3725992
+  dist_correction_x: 1.4353555
+  dist_correction_y: 1.3932405
+  focal_distance: 11.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 12
+  min_intensity: 50
+  rot_correction: -0.1255805045528199
+  two_pt_correction_available: true
+  vert_correction: -0.04526314018308893
+  vert_offset_correction: 0.20331627000000002
+- dist_correction: 1.3111591000000002
+  dist_correction_x: 1.3470857
+  dist_correction_y: 1.3652054000000002
+  focal_distance: 6.0
+  focal_slope: 0.69999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 13
+  min_intensity: 30
+  rot_correction: -0.06716508498014805
+  two_pt_correction_available: true
+  vert_correction: -0.03587557613263058
+  vert_offset_correction: 0.20399239000000002
+- dist_correction: 1.5360803
+  dist_correction_x: 1.5528035
+  dist_correction_y: 1.5666801000000001
+  focal_distance: 8.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 14
+  min_intensity: 20
+  rot_correction: -0.14578889529014513
+  two_pt_correction_available: true
+  vert_correction: -0.09893566067472198
+  vert_offset_correction: 0.19943586
+- dist_correction: 1.4755448999999998
+  dist_correction_x: 1.5032428
+  dist_correction_y: 1.5326752
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 15
+  min_intensity: 30
+  rot_correction: -0.08892898296002069
+  two_pt_correction_available: true
+  vert_correction: -0.09062974348423608
+  vert_offset_correction: 0.20003851
+- dist_correction: 1.4410587000000001
+  dist_correction_x: 1.4870845
+  dist_correction_y: 1.4627965
+  focal_distance: 18.0
+  focal_slope: 0.5
+  horiz_offset_correction: 0.025999999
+  laser_id: 16
+  min_intensity: 40
+  rot_correction: -0.013006177528832626
+  two_pt_correction_available: true
+  vert_correction: -0.02770725895504266
+  vert_offset_correction: 0.20458033
+- dist_correction: 1.4434521
+  dist_correction_x: 1.4897508
+  dist_correction_y: 1.4791382
+  focal_distance: 11.0
+  focal_slope: 0.80000001
+  horiz_offset_correction: -0.025999999
+  laser_id: 17
+  min_intensity: 55
+  rot_correction: 0.04596628970548614
+  two_pt_correction_available: true
+  vert_correction: -0.02014825541794774
+  vert_offset_correction: 0.20512417
+- dist_correction: 1.3243448000000002
+  dist_correction_x: 1.3816666000000002
+  dist_correction_y: 1.3647719
+  focal_distance: 12.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 18
+  min_intensity: 10
+  rot_correction: -0.03237303019110658
+  two_pt_correction_available: true
+  vert_correction: -0.08210824496987311
+  vert_offset_correction: 0.20065581999999998
+- dist_correction: 1.4565853999999998
+  dist_correction_x: 1.4340645
+  dist_correction_y: 1.4550516
+  focal_distance: 20.0
+  focal_slope: 0.69999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 19
+  min_intensity: 30
+  rot_correction: 0.02431275238487562
+  two_pt_correction_available: true
+  vert_correction: -0.0727614640280461
+  vert_offset_correction: 0.20133196000000003
+- dist_correction: 1.3313776
+  dist_correction_x: 1.3819601000000001
+  dist_correction_y: 1.3847791
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 20
+  min_intensity: 45
+  rot_correction: 0.10029393174916004
+  two_pt_correction_available: true
+  vert_correction: -0.009929893699589059
+  vert_offset_correction: 0.20585909000000002
+- dist_correction: 1.3787535
+  dist_correction_x: 1.3978789
+  dist_correction_y: 1.4257806
+  focal_distance: 10.0
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 21
+  min_intensity: 35
+  rot_correction: 0.15867894419560363
+  two_pt_correction_available: true
+  vert_correction: -0.0037977317325845416
+  vert_offset_correction: 0.20630005
+- dist_correction: 1.3419412
+  dist_correction_x: 1.4059189
+  dist_correction_y: 1.4113303
+  focal_distance: 11.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 22
+  min_intensity: 40
+  rot_correction: 0.08044522544540282
+  two_pt_correction_available: true
+  vert_correction: -0.06482699129962814
+  vert_offset_correction: 0.20190518999999998
+- dist_correction: 1.4338304
+  dist_correction_x: 1.4212059
+  dist_correction_y: 1.4900565000000001
+  focal_distance: 11.0
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 23
+  min_intensity: 55
+  rot_correction: 0.13867708175932542
+  two_pt_correction_available: true
+  vert_correction: -0.05566171063737453
+  vert_offset_correction: 0.20256662
+- dist_correction: 1.4930911
+  dist_correction_x: 1.5572188
+  dist_correction_y: 1.5182672
+  focal_distance: 5.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 24
+  min_intensity: 25
+  rot_correction: -0.12505298227706313
+  two_pt_correction_available: true
+  vert_correction: 0.06113007152996804
+  vert_offset_correction: 0.21097416
+- dist_correction: 1.4367653000000002
+  dist_correction_x: 1.4614236
+  dist_correction_y: 1.4587589
+  focal_distance: 3.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 25
+  min_intensity: 50
+  rot_correction: -0.06814826559971075
+  two_pt_correction_available: true
+  vert_correction: 0.06988221181432357
+  vert_offset_correction: 0.21160620000000002
+- dist_correction: 1.5279892000000002
+  dist_correction_x: 1.5686107999999999
+  dist_correction_y: 1.55737
+  focal_distance: 7.5
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 26
+  min_intensity: 30
+  rot_correction: -0.14531660046790917
+  two_pt_correction_available: true
+  vert_correction: 0.00887576771486082
+  vert_offset_correction: 0.20721134
+- dist_correction: 1.5077638
+  dist_correction_x: 1.5453738000000001
+  dist_correction_y: 1.5483368
+  focal_distance: 4.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 27
+  min_intensity: 30
+  rot_correction: -0.08904354811745085
+  two_pt_correction_available: true
+  vert_correction: 0.017050959569839413
+  vert_offset_correction: 0.20779928000000003
+- dist_correction: 1.3627797000000001
+  dist_correction_x: 1.4232985
+  dist_correction_y: 1.4116524000000001
+  focal_distance: 4.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 28
+  min_intensity: 50
+  rot_correction: -0.012061568860271928
+  two_pt_correction_available: true
+  vert_correction: 0.07842048992411524
+  vert_offset_correction: 0.21222351
+- dist_correction: 1.3749608
+  dist_correction_x: 1.4045798
+  dist_correction_y: 1.4006630999999998
+  focal_distance: 4.0
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 29
+  min_intensity: 40
+  rot_correction: 0.043892943273872005
+  two_pt_correction_available: true
+  vert_correction: 0.08674443287511571
+  vert_offset_correction: 0.21282616000000001
+- dist_correction: 1.2940709000000001
+  dist_correction_x: 1.392794
+  dist_correction_y: 1.3225565000000001
+  focal_distance: 8.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 30
+  min_intensity: 90
+  rot_correction: -0.033068739374902546
+  two_pt_correction_available: true
+  vert_correction: 0.02522388232225749
+  vert_offset_correction: 0.20838722
+- dist_correction: 1.3907666
+  dist_correction_x: 1.4365166
+  dist_correction_y: 1.4501437000000001
+  focal_distance: 9.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 31
+  min_intensity: 5
+  rot_correction: 0.025535290948715324
+  two_pt_correction_available: true
+  vert_correction: 0.034414332377654115
+  vert_offset_correction: 0.20904865
+- dist_correction: 1.3461819
+  dist_correction_x: 1.3678523000000002
+  dist_correction_y: 1.3552880999999999
+  focal_distance: 11.0
+  focal_slope: 1.5
+  horiz_offset_correction: 0.025999999
+  laser_id: 32
+  min_intensity: 45
+  rot_correction: -0.13309965698710405
+  two_pt_correction_available: true
+  vert_correction: -0.39666389380060213
+  vert_offset_correction: 0.10812234999999999
+- dist_correction: 1.2487466
+  dist_correction_x: 1.2929747
+  dist_correction_y: 1.3438803
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 33
+  min_intensity: 35
+  rot_correction: -0.07241159183553281
+  two_pt_correction_available: true
+  vert_correction: -0.39021216204755743
+  vert_offset_correction: 0.10859233
+- dist_correction: 1.5016498000000003
+  dist_correction_x: 1.5384890999999998
+  dist_correction_y: 1.5506186
+  focal_distance: 4.5
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 34
+  min_intensity: 20
+  rot_correction: 0.08292710807634829
+  two_pt_correction_available: true
+  vert_correction: -0.2010672181773803
+  vert_offset_correction: 0.12148494
+- dist_correction: 1.2495708
+  dist_correction_x: 1.2891127
+  dist_correction_y: 1.2943669
+  focal_distance: 11.0
+  focal_slope: 1.3
+  horiz_offset_correction: -0.025999999
+  laser_id: 35
+  min_intensity: 25
+  rot_correction: 0.14006506182829093
+  two_pt_correction_available: true
+  vert_correction: -0.19103771853737994
+  vert_offset_correction: 0.12213274
+- dist_correction: 1.2674536
+  dist_correction_x: 1.3298663
+  dist_correction_y: 1.3577469
+  focal_distance: 6.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 36
+  min_intensity: 35
+  rot_correction: -0.012004346320883118
+  two_pt_correction_available: true
+  vert_correction: -0.3819670695815035
+  vert_offset_correction: 0.10918932
+- dist_correction: 1.2481956
+  dist_correction_x: 1.28627
+  dist_correction_y: 1.29235
+  focal_distance: 14.5
+  focal_slope: 1.5
+  horiz_offset_correction: -0.025999999
+  laser_id: 37
+  min_intensity: 30
+  rot_correction: 0.04832190474636683
+  two_pt_correction_available: true
+  vert_correction: -0.3718940414299584
+  vert_offset_correction: 0.10991334
+- dist_correction: 1.4516722
+  dist_correction_x: 1.4842308
+  dist_correction_y: 1.4868384000000001
+  focal_distance: 4.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 38
+  min_intensity: 55
+  rot_correction: -0.03583078923869515
+  two_pt_correction_available: true
+  vert_correction: -0.4336284663746853
+  vert_offset_correction: 0.1053787
+- dist_correction: 1.3843003999999999
+  dist_correction_x: 1.4010727
+  dist_correction_y: 1.4332015999999999
+  focal_distance: 6.5
+  focal_slope: 1.3
+  horiz_offset_correction: -0.025999999
+  laser_id: 39
+  min_intensity: 40
+  rot_correction: 0.026883486237381612
+  two_pt_correction_available: true
+  vert_correction: -0.4261966798867682
+  vert_offset_correction: 0.10593759000000001
+- dist_correction: 1.244738
+  dist_correction_x: 1.3131859000000001
+  dist_correction_y: 1.354245
+  focal_distance: 6.5
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 40
+  min_intensity: 25
+  rot_correction: 0.1076316048478218
+  two_pt_correction_available: true
+  vert_correction: -0.3640637439139335
+  vert_offset_correction: 0.11047223
+- dist_correction: 1.3284543
+  dist_correction_x: 1.3295518000000002
+  dist_correction_y: 1.3809489
+  focal_distance: 12.5
+  focal_slope: 1.7
+  horiz_offset_correction: -0.025999999
+  laser_id: 41
+  min_intensity: 50
+  rot_correction: 0.1679293847080498
+  two_pt_correction_available: true
+  vert_correction: -0.3511493721000192
+  vert_offset_correction: 0.11138678
+- dist_correction: 1.4055542
+  dist_correction_x: 1.4426663
+  dist_correction_y: 1.430847
+  focal_distance: 1.5
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 42
+  min_intensity: 10
+  rot_correction: 0.0861156692854385
+  two_pt_correction_available: true
+  vert_correction: -0.4163231777753111
+  vert_offset_correction: 0.10667431000000001
+- dist_correction: 1.3529747
+  dist_correction_x: 1.3834917999999998
+  dist_correction_y: 1.4029074
+  focal_distance: 6.0
+  focal_slope: 1.2
+  horiz_offset_correction: -0.025999999
+  laser_id: 43
+  min_intensity: 35
+  rot_correction: 0.15024020221305323
+  two_pt_correction_available: true
+  vert_correction: -0.4046365927302973
+  vert_offset_correction: 0.10753805
+- dist_correction: 1.2407380000000001
+  dist_correction_x: 1.3171521000000002
+  dist_correction_y: 1.2836400000000001
+  focal_distance: 15.0
+  focal_slope: 1.6
+  horiz_offset_correction: 0.025999999
+  laser_id: 44
+  max_intensity: 220
+  rot_correction: -0.12998527227122358
+  two_pt_correction_available: true
+  vert_correction: -0.28892197890806653
+  vert_offset_correction: 0.11568009
+- dist_correction: 1.5288051999999999
+  dist_correction_x: 1.5904514
+  dist_correction_y: 1.6288455
+  focal_distance: 10.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 45
+  rot_correction: -0.07009281894983248
+  two_pt_correction_available: true
+  vert_correction: -0.28120381879648226
+  vert_offset_correction: 0.11620087
+- dist_correction: 1.5423979
+  dist_correction_x: 1.5919412
+  dist_correction_y: 1.610177
+  focal_distance: 13.0
+  focal_slope: 1.7
+  horiz_offset_correction: 0.025999999
+  laser_id: 46
+  rot_correction: -0.1533711640661691
+  two_pt_correction_available: true
+  vert_correction: -0.34156398894148127
+  vert_offset_correction: 0.11205999
+- dist_correction: 1.3086252999999999
+  dist_correction_x: 1.3737134
+  dist_correction_y: 1.4177727
+  focal_distance: 5.5
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 47
+  rot_correction: -0.0927890927600715
+  two_pt_correction_available: true
+  vert_correction: -0.3348332488542128
+  vert_offset_correction: 0.11252997
+- dist_correction: 1.3405330000000002
+  dist_correction_x: 1.4512436
+  dist_correction_y: 1.4471467999999998
+  focal_distance: 13.5
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 48
+  rot_correction: -0.012004348415278218
+  two_pt_correction_available: true
+  vert_correction: -0.2738300470529015
+  vert_offset_correction: 0.11669625
+- dist_correction: 1.2994545
+  dist_correction_x: 1.3971343999999999
+  dist_correction_y: 1.36849
+  focal_distance: 14.0
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 49
+  rot_correction: 0.047471358677980184
+  two_pt_correction_available: true
+  vert_correction: -0.2649030020882158
+  vert_offset_correction: 0.11729325
+- dist_correction: 1.4499762999999999
+  dist_correction_x: 1.5111346
+  dist_correction_y: 1.542395
+  focal_distance: 13.0
+  focal_slope: 1.2
+  horiz_offset_correction: 0.025999999
+  laser_id: 50
+  rot_correction: -0.03378136079915033
+  two_pt_correction_available: true
+  vert_correction: -0.32678797913421975
+  vert_offset_correction: 0.11308886
+- dist_correction: 1.3516956
+  dist_correction_x: 1.4231836999999998
+  dist_correction_y: 1.4301146
+  focal_distance: 13.0
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 51
+  rot_correction: 0.025334358173250228
+  two_pt_correction_available: true
+  vert_correction: -0.3179609589889659
+  vert_offset_correction: 0.11369856
+- dist_correction: 1.2374236
+  dist_correction_x: 1.308008
+  dist_correction_y: 1.3549429000000002
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: 0.025999999
+  laser_id: 52
+  rot_correction: 0.10481975724981128
+  two_pt_correction_available: true
+  vert_correction: -0.25478428121685354
+  vert_offset_correction: 0.11796646000000001
+- dist_correction: 1.3730562000000002
+  dist_correction_x: 1.403678
+  dist_correction_y: 1.4347415000000001
+  focal_distance: 13.0
+  focal_slope: 1.4
+  horiz_offset_correction: -0.025999999
+  laser_id: 53
+  rot_correction: 0.16311715242247551
+  two_pt_correction_available: true
+  vert_correction: -0.24576616497179882
+  vert_offset_correction: 0.11856346000000001
+- dist_correction: 1.4445888
+  dist_correction_x: 1.5025624
+  dist_correction_y: 1.5189749000000001
+  focal_distance: 10.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 54
+  rot_correction: 0.08384971878954978
+  two_pt_correction_available: true
+  vert_correction: -0.31000962288931516
+  vert_offset_correction: 0.11424474999999999
+- dist_correction: 1.3861449
+  dist_correction_x: 1.4228815000000001
+  dist_correction_y: 1.4620186000000002
+  focal_distance: 15.0
+  focal_slope: 1.6
+  horiz_offset_correction: -0.025999999
+  laser_id: 55
+  rot_correction: 0.14374613400834294
+  two_pt_correction_available: true
+  vert_correction: -0.2986601307360315
+  vert_offset_correction: 0.11501958000000001
+- dist_correction: 1.4635341
+  dist_correction_x: 1.5232283000000002
+  dist_correction_y: 1.5063837000000002
+  focal_distance: 13.0
+  focal_slope: 1.3
+  horiz_offset_correction: 0.025999999
+  laser_id: 56
+  rot_correction: -0.12741928396895377
+  two_pt_correction_available: true
+  vert_correction: -0.18393445537456576
+  vert_offset_correction: 0.12259002000000001
+- dist_correction: 1.3715826000000002
+  dist_correction_x: 1.4186972
+  dist_correction_y: 1.4328435
+  focal_distance: 3.5
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 57
+  rot_correction: -0.06853129555735342
+  two_pt_correction_available: true
+  vert_correction: -0.1744342722087932
+  vert_offset_correction: 0.12319972
+- dist_correction: 1.4644831999999999
+  dist_correction_x: 1.5095984000000002
+  dist_correction_y: 1.5149265
+  focal_distance: 11.0
+  focal_slope: 1.4
+  horiz_offset_correction: 0.025999999
+  laser_id: 58
+  rot_correction: -0.1497316045423758
+  two_pt_correction_available: true
+  vert_correction: -0.23400086557751998
+  vert_offset_correction: 0.11933828
+- dist_correction: 1.3074548
+  dist_correction_x: 1.3521214000000001
+  dist_correction_y: 1.3830151000000002
+  focal_distance: 5.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 59
+  rot_correction: -0.08973572126418226
+  two_pt_correction_available: true
+  vert_correction: -0.22644383426247983
+  vert_offset_correction: 0.11983367
+- dist_correction: 1.4378391
+  dist_correction_x: 1.4799687000000001
+  dist_correction_y: 1.4889211
+  focal_distance: 5.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 60
+  rot_correction: -0.011751946229237658
+  two_pt_correction_available: true
+  vert_correction: -0.1678843098347878
+  vert_offset_correction: 0.12361888
+- dist_correction: 1.3585466
+  dist_correction_x: 1.4135242
+  dist_correction_y: 1.4170488
+  focal_distance: 2.0
+  focal_slope: 0.89999998
+  horiz_offset_correction: -0.025999999
+  laser_id: 61
+  rot_correction: 0.04489272721060892
+  two_pt_correction_available: true
+  vert_correction: -0.158331168143522
+  vert_offset_correction: 0.12422858
+- dist_correction: 1.4478067
+  dist_correction_x: 1.5442529
+  dist_correction_y: 1.5512207
+  focal_distance: 10.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 62
+  rot_correction: -0.0340408982402389
+  two_pt_correction_available: true
+  vert_correction: -0.21671681763514258
+  vert_offset_correction: 0.12046877
+- dist_correction: 1.4329738
+  dist_correction_x: 1.4817114
+  dist_correction_y: 1.4954124
+  focal_distance: 9.0
+  focal_slope: 0.80000001
+  horiz_offset_correction: -0.025999999
+  laser_id: 63
+  rot_correction: 0.024857907722065305
+  two_pt_correction_available: true
+  vert_correction: -0.2106649408137298
+  vert_offset_correction: 0.12086253
+num_lasers: 64

--- a/velodyne_pointcloud/params/64e_s3-xiesc.yaml
+++ b/velodyne_pointcloud/params/64e_s3-xiesc.yaml
@@ -1,227 +1,725 @@
-lasers:
-- {dist_correction: 1.4139490000000001, dist_correction_x: 1.4198446999999998, dist_correction_y: 1.4058145,
-  focal_distance: 10.5, focal_slope: 1.85, horiz_offset_correction: 0.025999999, laser_id: 0,
-  min_intensity: 5, rot_correction: -0.07648247457737148, vert_correction: -0.1261818455292898,
-  vert_offset_correction: 0.21569468}
-- {dist_correction: 1.5094685, dist_correction_x: 1.5403023, dist_correction_y: 1.5012577999999999,
-  focal_distance: 15.0, focal_slope: 1.2, horiz_offset_correction: -0.025999999, laser_id: 1,
-  min_intensity: 10, rot_correction: -0.03932070772308096, vert_correction: -0.11953745909742221,
-  vert_offset_correction: 0.21520962000000002}
-- {dist_correction: 1.4579400999999999, dist_correction_x: 1.4846666, dist_correction_y: 1.4228239,
-  focal_distance: 24.0, focal_slope: 1.05, horiz_offset_correction: 0.025999999, laser_id: 2,
-  min_intensity: 30, rot_correction: 0.06005350008746038, vert_correction: 0.00356118725906175,
-  vert_offset_correction: 0.20631704}
-- {dist_correction: 1.5046124, dist_correction_x: 1.5335535999999999, dist_correction_y: 1.5401996,
-  focal_distance: 14.5, focal_slope: 1.7, horiz_offset_correction: -0.025999999, laser_id: 3,
-  min_intensity: 10, rot_correction: 0.09919490315516696, vert_correction: 0.010306535403103584,
-  vert_offset_correction: 0.20583200000000001}
-- {dist_correction: 1.4370993, dist_correction_x: 1.4714845, dist_correction_y: 1.4524646,
-  focal_distance: 15.0, focal_slope: 0.40000001, horiz_offset_correction: 0.025999999,
-  laser_id: 4, min_intensity: 30, rot_correction: -0.00095355016485159, vert_correction: -0.1144967440141401,
-  vert_offset_correction: 0.21484217000000003}
-- {dist_correction: 1.3536626999999999, dist_correction_x: 1.3909094, dist_correction_y: 1.3700326999999999,
-  focal_distance: 17.0, focal_slope: 1.45, horiz_offset_correction: -0.025999999,
-  laser_id: 5, min_intensity: 30, rot_correction: 0.03824387099052699, vert_correction: -0.10803612329921503,
-  vert_offset_correction: 0.21437181}
-- {dist_correction: 1.4117873, dist_correction_x: 1.4350795, dist_correction_y: 1.3829624999999999,
-  focal_distance: 10.5, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 6,
-  min_intensity: 10, rot_correction: -0.015297255529962315, vert_correction: -0.14944538101702426,
-  vert_offset_correction: 0.21739968999999998}
-- {dist_correction: 1.4269646, dist_correction_x: 1.451161, dist_correction_y: 1.4328421,
-  focal_distance: 14.0, focal_slope: 1.3, horiz_offset_correction: -0.025999999, laser_id: 7,
-  min_intensity: 10, rot_correction: 0.024255809272700053, vert_correction: -0.14344353231329066,
-  vert_offset_correction: 0.21695873}
-- {dist_correction: 1.3808284000000002, dist_correction_x: 1.421472, dist_correction_y: 1.3838283000000002,
-  focal_distance: 15.0, focal_slope: 0.94999999, horiz_offset_correction: 0.025999999,
-  laser_id: 8, min_intensity: 30, rot_correction: 0.07354442571180776, vert_correction: -0.10278016723125998,
-  vert_offset_correction: 0.21398966000000003}
-- {dist_correction: 1.3644336000000001, dist_correction_x: 1.3931616, dist_correction_y: 1.3852122,
-  focal_distance: 12.5, focal_slope: 1.95, horiz_offset_correction: -0.025999999,
-  laser_id: 9, min_intensity: 10, rot_correction: 0.11317857886058363, vert_correction: -0.09569590023202451,
-  vert_offset_correction: 0.21347521}
-- {dist_correction: 1.4102663000000002, dist_correction_x: 1.4163402, dist_correction_y: 1.3592377,
-  focal_distance: 12.5, focal_slope: 1.95, horiz_offset_correction: 0.025999999, laser_id: 10,
-  min_intensity: 10, rot_correction: 0.05954228616823424, vert_correction: -0.1386345201601863,
-  vert_offset_correction: 0.21660597}
-- {dist_correction: 1.5019737000000002, dist_correction_x: 1.532475, dist_correction_y: 1.5237663000000001,
-  focal_distance: 13.0, focal_slope: 1.9, horiz_offset_correction: -0.025999999, laser_id: 11,
-  min_intensity: 10, rot_correction: 0.09906092120980835, vert_correction: -0.13181073657049397,
-  vert_offset_correction: 0.21610622}
-- {dist_correction: 1.4399905000000002, dist_correction_x: 1.4887962, dist_correction_y: 1.4455237,
-  focal_distance: 14.5, focal_slope: 1.7, horiz_offset_correction: 0.025999999, laser_id: 12,
-  max_intensity: 235, rot_correction: -0.07574798243226695, vert_correction: -0.054438932963427306,
-  vert_offset_correction: 0.21049141}
-- {dist_correction: 1.5207593, dist_correction_x: 1.5401453, dist_correction_y: 1.5190082,
-  focal_distance: 20.5, focal_slope: 1.25, horiz_offset_correction: -0.025999999,
-  laser_id: 13, max_intensity: 240, rot_correction: -0.037047761947550245, vert_correction: -0.048730533448148504,
-  vert_offset_correction: 0.21007986}
-- {dist_correction: 1.4746239, dist_correction_x: 1.5300989999999999, dist_correction_y: 1.4663734,
-  focal_distance: 12.5, focal_slope: 1.9, horiz_offset_correction: 0.025999999, laser_id: 14,
-  max_intensity: 245, rot_correction: -0.0895955468906376, vert_correction: -0.08961595328025192,
-  vert_offset_correction: 0.21303425}
-- {dist_correction: 1.4697629, dist_correction_x: 1.5051735, dist_correction_y: 1.4558601,
-  focal_distance: 19.5, focal_slope: 0.94999999, horiz_offset_correction: -0.025999999,
-  laser_id: 15, max_intensity: 245, rot_correction: -0.05072966149865084, vert_correction: -0.0839353306800186,
-  vert_offset_correction: 0.21262267999999998}
-- {dist_correction: 1.4143376, dist_correction_x: 1.4432597000000003, dist_correction_y: 1.4038483,
-  focal_distance: 24.0, focal_slope: 0.69999999, horiz_offset_correction: 0.025999999,
-  laser_id: 16, max_intensity: 245, rot_correction: -0.001864320564407547, vert_correction: -0.043427018903405855,
-  vert_offset_correction: 0.20969770000000001}
-- {dist_correction: 1.4815961, dist_correction_x: 1.5173615, dist_correction_y: 1.4871606,
-  focal_distance: 14.5, focal_slope: 1.65, horiz_offset_correction: -0.025999999,
-  laser_id: 17, rot_correction: 0.03747852840556422, vert_correction: -0.03648801216715539,
-  vert_offset_correction: 0.20919794}
-- {dist_correction: 1.420331, dist_correction_x: 1.4755219, dist_correction_y: 1.3919118000000001,
-  focal_distance: 17.5, focal_slope: 1.4, horiz_offset_correction: 0.025999999, laser_id: 18,
-  rot_correction: -0.015194972429011364, vert_correction: -0.07906187922560139, vert_offset_correction: 0.21226994000000002}
-- {dist_correction: 1.4900717, dist_correction_x: 1.5143349000000002, dist_correction_y: 1.4829907,
-  focal_distance: 24.0, focal_slope: 1.25, horiz_offset_correction: -0.025999999,
-  laser_id: 19, rot_correction: 0.02391977928648433, vert_correction: -0.07255814015150577,
-  vert_offset_correction: 0.21179958}
-- {dist_correction: 1.4823865, dist_correction_x: 1.5357741999999999, dist_correction_y: 1.4956403,
-  focal_distance: 24.0, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 20,
-  rot_correction: 0.07264374331532833, vert_correction: -0.031587736747464255, vert_offset_correction: 0.20884519999999998}
-- {dist_correction: 1.5553201, dist_correction_x: 1.5698593, dist_correction_y: 1.5624425,
-  focal_distance: 15.5, focal_slope: 1.55, horiz_offset_correction: -0.025999999,
-  laser_id: 21, rot_correction: 0.11143265968730214, vert_correction: -0.025460288914769372,
-  vert_offset_correction: 0.20840424}
-- {dist_correction: 1.4437845999999999, dist_correction_x: 1.4909378000000002, dist_correction_y: 1.4347861,
-  focal_distance: 20.5, focal_slope: 1.2, horiz_offset_correction: 0.025999999, laser_id: 22,
-  rot_correction: 0.05942554283989759, vert_correction: -0.06665878416276627, vert_offset_correction: 0.21137333000000003}
-- {dist_correction: 1.4939513, dist_correction_x: 1.5194868, dist_correction_y: 1.5106346,
-  focal_distance: 14.5, focal_slope: 1.65, horiz_offset_correction: -0.025999999,
-  laser_id: 23, rot_correction: 0.09797042203986979, vert_correction: -0.06055112836378901,
-  vert_offset_correction: 0.21093236999999998}
-- {dist_correction: 1.4521244999999998, dist_correction_x: 1.4884882, dist_correction_y: 1.4649333,
-  focal_distance: 11.5, focal_slope: 2.0, horiz_offset_correction: 0.025999999, laser_id: 24,
-  rot_correction: -0.07658879305408597, vert_correction: 0.015620435355027301, vert_offset_correction: 0.20544985000000002}
-- {dist_correction: 1.5351622, dist_correction_x: 1.524973, dist_correction_y: 1.5029565,
-  focal_distance: 18.5, focal_slope: 1.25, horiz_offset_correction: -0.025999999,
-  laser_id: 25, rot_correction: -0.0379098725675606, vert_correction: 0.022567997346205196,
-  vert_offset_correction: 0.20495010000000002}
-- {dist_correction: 1.5321327, dist_correction_x: 1.5833431999999998, dist_correction_y: 1.5359726,
-  focal_distance: 13.0, focal_slope: 1.9, horiz_offset_correction: 0.025999999, laser_id: 26,
-  rot_correction: -0.0904730670226138, vert_correction: -0.019943931467746017, vert_offset_correction: 0.20800737000000002}
-- {dist_correction: 1.5166023000000002, dist_correction_x: 1.4874829, dist_correction_y: 1.4625635,
-  focal_distance: 21.5, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 27,
-  rot_correction: -0.051308328902808065, vert_correction: -0.013200099491225388, vert_offset_correction: 0.20752234000000003}
-- {dist_correction: 1.4549194, dist_correction_x: 1.4688664, dist_correction_y: 1.4194371000000001,
-  focal_distance: 13.5, focal_slope: 1.83, horiz_offset_correction: 0.025999999, laser_id: 28,
-  rot_correction: -0.0019143155208309244, vert_correction: 0.027266617424120905, vert_offset_correction: 0.20461203000000003}
-- {dist_correction: 1.5617532, dist_correction_x: 1.5887217999999999, dist_correction_y: 1.5643922000000001,
-  focal_distance: 18.5, focal_slope: 1.35, horiz_offset_correction: -0.025999999,
-  laser_id: 29, rot_correction: 0.03681404490741569, vert_correction: 0.03421014630846329,
-  vert_offset_correction: 0.20411228}
-- {dist_correction: 1.5132924, dist_correction_x: 1.5661812000000002, dist_correction_y: 1.5102689,
-  focal_distance: 18.5, focal_slope: 1.35, horiz_offset_correction: 0.025999999, laser_id: 30,
-  rot_correction: -0.015542064486559148, vert_correction: -0.007885903531460533, vert_offset_correction: 0.20714018}
-- {dist_correction: 1.5638524, dist_correction_x: 1.5621136000000002, dist_correction_y: 1.5383017,
-  focal_distance: 21.5, focal_slope: 1.15, horiz_offset_correction: -0.025999999,
-  laser_id: 31, rot_correction: 0.023284423588222334, vert_correction: -0.0015491891506552067,
-  vert_offset_correction: 0.20668451000000002}
-- {dist_correction: 1.3077792, dist_correction_x: 1.3433452, dist_correction_y: 1.2840973,
-  focal_distance: 10.5, focal_slope: 2.0, horiz_offset_correction: 0.025999999, laser_id: 32,
-  rot_correction: -0.1278634161583795, vert_correction: -0.39021216204755743, vert_offset_correction: 0.15970787}
-- {dist_correction: 1.4303885, dist_correction_x: 1.4429931999999999, dist_correction_y: 1.4607234,
-  focal_distance: 0.25, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 33,
-  rot_correction: -0.066528586091226, vert_correction: -0.38355018793281753, vert_offset_correction: 0.15922519}
-- {dist_correction: 1.3746819, dist_correction_x: 1.3873923, dist_correction_y: 1.4089924999999999,
-  focal_distance: 0.25, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 34,
-  rot_correction: 0.08854290740283328, vert_correction: -0.197138848550284, vert_offset_correction: 0.14656122}
-- {dist_correction: 1.3814778, dist_correction_x: 1.3932765, dist_correction_y: 1.4301869,
-  focal_distance: 11.0, focal_slope: 2.0, horiz_offset_correction: -0.025999999, laser_id: 35,
-  rot_correction: 0.14547956884148489, vert_correction: -0.18768579625563228, vert_offset_correction: 0.14595152}
-- {dist_correction: 1.4313307, dist_correction_x: 1.4734517, dist_correction_y: 1.4390849000000001,
-  focal_distance: 9.5, focal_slope: 1.85, horiz_offset_correction: 0.025999999, laser_id: 36,
-  rot_correction: -0.005071588212420635, vert_correction: -0.3750836655445631, vert_offset_correction: 0.15861549}
-- {dist_correction: 1.3414835, dist_correction_x: 1.3820609, dist_correction_y: 1.355589,
-  focal_distance: 9.5, focal_slope: 1.4, horiz_offset_correction: -0.025999999, laser_id: 37,
-  rot_correction: 0.05427589303135225, vert_correction: -0.36762882325722723, vert_offset_correction: 0.15808201}
-- {dist_correction: 1.4895827, dist_correction_x: 1.5283238000000001, dist_correction_y: 1.4803529,
-  focal_distance: 9.0, focal_slope: 1.65, horiz_offset_correction: 0.025999999, laser_id: 38,
-  rot_correction: -0.028143856558087547, vert_correction: -0.4285668719175616, vert_offset_correction: 0.16254044}
-- {dist_correction: 1.3727733000000002, dist_correction_x: 1.3623596, dist_correction_y: 1.392661,
-  focal_distance: 0.25, focal_slope: 1.15, horiz_offset_correction: -0.025999999,
-  laser_id: 39, rot_correction: 0.03172272051181349, vert_correction: -0.4214410765541042,
-  vert_offset_correction: 0.16200695}
-- {dist_correction: 1.4348983999999998, dist_correction_x: 1.4775407000000003, dist_correction_y: 1.4712174999999998,
-  focal_distance: 0.25, focal_slope: 0.92000002, horiz_offset_correction: 0.025999999,
-  laser_id: 40, rot_correction: 0.11411698480351568, vert_correction: -0.3565455112681652,
-  vert_offset_correction: 0.15729448}
-- {dist_correction: 1.335618, dist_correction_x: 1.3519691, dist_correction_y: 1.3315152000000001,
-  focal_distance: 11.200000000000001, focal_slope: 2.0, horiz_offset_correction: -0.025999999,
-  laser_id: 41, rot_correction: 0.1735498527902839, vert_correction: -0.34717860842539194,
-  vert_offset_correction: 0.15663397}
-- {dist_correction: 1.4905824, dist_correction_x: 1.488313, dist_correction_y: 1.4948479000000001,
-  focal_distance: 0.25, focal_slope: 1.1, horiz_offset_correction: 0.025999999, laser_id: 42,
-  rot_correction: 0.09564756333839054, vert_correction: -0.4110102035460227, vert_offset_correction: 0.16123213}
-- {dist_correction: 1.3288423, dist_correction_x: 1.3409723, dist_correction_y: 1.3440451,
-  focal_distance: 10.0, focal_slope: 1.95, horiz_offset_correction: -0.025999999,
-  laser_id: 43, rot_correction: 0.15538288292189534, vert_correction: -0.40083030888437793,
-  vert_offset_correction: 0.16048269}
-- {dist_correction: 1.3771290999999999, dist_correction_x: 1.3773239000000002, dist_correction_y: 1.3497290000000002,
-  focal_distance: 11.5, focal_slope: 2.0, horiz_offset_correction: 0.025999999, laser_id: 44,
-  rot_correction: -0.12413605610123538, vert_correction: -0.2840315837972709, vert_offset_correction: 0.15228986}
-- {dist_correction: 1.3367807, dist_correction_x: 1.370152, dist_correction_y: 1.370934,
-  focal_distance: 0.25, focal_slope: 0.44999999, horiz_offset_correction: -0.025999999,
-  laser_id: 45, rot_correction: -0.06413447432303407, vert_correction: -0.27761533458791926,
-  vert_offset_correction: 0.15185799}
-- {dist_correction: 1.4788651, dist_correction_x: 1.5014308, dist_correction_y: 1.4727454,
-  focal_distance: 11.5, focal_slope: 2.0, horiz_offset_correction: 0.025999999, laser_id: 46,
-  rot_correction: -0.14872602785785152, vert_correction: -0.3359268721635124, vert_offset_correction: 0.15584644}
-- {dist_correction: 1.3220766000000002, dist_correction_x: 1.3654865, dist_correction_y: 1.3739757000000001,
-  focal_distance: 0.25, focal_slope: 0.94999999, horiz_offset_correction: -0.025999999,
-  laser_id: 47, rot_correction: -0.08707280959256145, vert_correction: -0.33026751989087316,
-  vert_offset_correction: 0.15545268}
-- {dist_correction: 1.4612433999999999, dist_correction_x: 1.5250436, dist_correction_y: 1.4817635999999998,
-  focal_distance: 13.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 48,
-  rot_correction: -0.006799911150716457, vert_correction: -0.26851710773019805, vert_offset_correction: 0.15124829}
-- {dist_correction: 1.3407353000000002, dist_correction_x: 1.3478844, dist_correction_y: 1.3154279,
-  focal_distance: 13.5, focal_slope: 1.8, horiz_offset_correction: -0.025999999, laser_id: 49,
-  rot_correction: 0.05242808851765633, vert_correction: -0.26051854302098837, vert_offset_correction: 0.1507148}
-- {dist_correction: 1.3465115, dist_correction_x: 1.3874431999999999, dist_correction_y: 1.3508052000000002,
-  focal_distance: 12.0, focal_slope: 1.85, horiz_offset_correction: 0.025999999, laser_id: 50,
-  rot_correction: -0.028383715411859876, vert_correction: -0.3216451745070007, vert_offset_correction: 0.15485568000000002}
-- {dist_correction: 1.3629696999999998, dist_correction_x: 1.4037315000000001, dist_correction_y: 1.3869237,
-  focal_distance: 12.0, focal_slope: 1.1, horiz_offset_correction: -0.025999999, laser_id: 51,
-  rot_correction: 0.031843273893907245, vert_correction: -0.3135280670349956, vert_offset_correction: 0.15429679000000002}
-- {dist_correction: 1.4472754, dist_correction_x: 1.4817390000000001, dist_correction_y: 1.4782272,
-  focal_distance: 2.0, focal_slope: 1.0, horiz_offset_correction: 0.025999999, laser_id: 52,
-  rot_correction: 0.10955275158734502, vert_correction: -0.24941678290173272, vert_offset_correction: 0.14997807999999999}
-- {dist_correction: 1.3800671, dist_correction_x: 1.3796414, dist_correction_y: 1.3943782,
-  focal_distance: 11.200000000000001, focal_slope: 2.0, horiz_offset_correction: -0.025999999,
-  laser_id: 53, rot_correction: 0.16876716543828738, vert_correction: -0.2409525119882134,
-  vert_offset_correction: 0.14941919}
-- {dist_correction: 1.5190169, dist_correction_x: 1.5619051, dist_correction_y: 1.5511705,
-  focal_distance: 2.5, focal_slope: 1.05, horiz_offset_correction: 0.025999999, laser_id: 54,
-  rot_correction: 0.09037283276367176, vert_correction: -0.30313513748485243, vert_offset_correction: 0.15358547}
-- {dist_correction: 1.3803656000000002, dist_correction_x: 1.3960698, dist_correction_y: 1.386106,
-  focal_distance: 12.5, focal_slope: 1.9, horiz_offset_correction: -0.025999999, laser_id: 55,
-  rot_correction: 0.14871534295217081, vert_correction: -0.29323634555253386, vert_offset_correction: 0.15291226}
-- {dist_correction: 1.5827696, dist_correction_x: 1.6050609, dist_correction_y: 1.5844797,
-  focal_distance: 10.0, focal_slope: 1.95, horiz_offset_correction: 0.025999999, laser_id: 56,
-  rot_correction: -0.12100867217308608, vert_correction: -0.17760463486977288, vert_offset_correction: 0.14530372}
-- {dist_correction: 1.3843919, dist_correction_x: 1.3915251000000002, dist_correction_y: 1.4156927,
-  focal_distance: 0.25, focal_slope: 0.94999999, horiz_offset_correction: -0.025999999,
-  laser_id: 57, rot_correction: -0.06431965899265843, vert_correction: -0.17006926832673774,
-  vert_offset_correction: 0.14482104}
-- {dist_correction: 1.5491273, dist_correction_x: 1.5298964000000002, dist_correction_y: 1.5107637,
-  focal_distance: 11.5, focal_slope: 2.0, horiz_offset_correction: 0.025999999, laser_id: 58,
-  rot_correction: -0.14486168214370612, vert_correction: -0.22974121500510264, vert_offset_correction: 0.14868247}
-- {dist_correction: 1.3646004, dist_correction_x: 1.3803583000000001, dist_correction_y: 1.4061511,
-  focal_distance: 0.25, focal_slope: 1.0, horiz_offset_correction: -0.025999999, laser_id: 59,
-  rot_correction: -0.0852480451703211, vert_correction: -0.22391891879349718, vert_offset_correction: 0.14830141}
-- {dist_correction: 1.5239935, dist_correction_x: 1.560786, dist_correction_y: 1.5632524,
-  focal_distance: 5.0, focal_slope: 1.15, horiz_offset_correction: 0.025999999, laser_id: 60,
-  rot_correction: -0.005967226432828876, vert_correction: -0.16231529056824404, vert_offset_correction: 0.14432566}
-- {dist_correction: 1.4112029000000001, dist_correction_x: 1.4223886, dist_correction_y: 1.4542918,
-  focal_distance: 2.5, focal_slope: 1.05, horiz_offset_correction: -0.025999999, laser_id: 61,
-  rot_correction: 0.050600613599087636, vert_correction: -0.15314424682880032, vert_offset_correction: 0.14374136}
-- {dist_correction: 1.5013637, dist_correction_x: 1.5208610999999999, dist_correction_y: 1.5006433000000001,
-  focal_distance: 16.5, focal_slope: 1.25, horiz_offset_correction: 0.025999999, laser_id: 62,
-  rot_correction: -0.027436902217920986, vert_correction: -0.21457119711920336, vert_offset_correction: 0.14769171}
-- {dist_correction: 1.4423058, dist_correction_x: 1.4454633000000001, dist_correction_y: 1.4321198000000002,
-  focal_distance: 9.0, focal_slope: 1.45, horiz_offset_correction: -0.025999999, laser_id: 63,
-  rot_correction: 0.0290479702718764, vert_correction: -0.2079266762969834, vert_offset_correction: 0.14725984}
-num_lasers: 64
 distance_resolution: 0.002
+lasers:
+- dist_correction: 1.4139490000000001
+  dist_correction_x: 1.4198446999999998
+  dist_correction_y: 1.4058145
+  focal_distance: 10.5
+  focal_slope: 1.85
+  horiz_offset_correction: 0.025999999
+  laser_id: 0
+  min_intensity: 5
+  rot_correction: -0.07648247457737148
+  two_pt_correction_available: true
+  vert_correction: -0.1261818455292898
+  vert_offset_correction: 0.21569468
+- dist_correction: 1.5094685
+  dist_correction_x: 1.5403023
+  dist_correction_y: 1.5012577999999999
+  focal_distance: 15.0
+  focal_slope: 1.2
+  horiz_offset_correction: -0.025999999
+  laser_id: 1
+  min_intensity: 10
+  rot_correction: -0.03932070772308096
+  two_pt_correction_available: true
+  vert_correction: -0.11953745909742221
+  vert_offset_correction: 0.21520962000000002
+- dist_correction: 1.4579400999999999
+  dist_correction_x: 1.4846666
+  dist_correction_y: 1.4228239
+  focal_distance: 24.0
+  focal_slope: 1.05
+  horiz_offset_correction: 0.025999999
+  laser_id: 2
+  min_intensity: 30
+  rot_correction: 0.06005350008746038
+  two_pt_correction_available: true
+  vert_correction: 0.00356118725906175
+  vert_offset_correction: 0.20631704
+- dist_correction: 1.5046124
+  dist_correction_x: 1.5335535999999999
+  dist_correction_y: 1.5401996
+  focal_distance: 14.5
+  focal_slope: 1.7
+  horiz_offset_correction: -0.025999999
+  laser_id: 3
+  min_intensity: 10
+  rot_correction: 0.09919490315516696
+  two_pt_correction_available: true
+  vert_correction: 0.010306535403103584
+  vert_offset_correction: 0.20583200000000001
+- dist_correction: 1.4370993
+  dist_correction_x: 1.4714845
+  dist_correction_y: 1.4524646
+  focal_distance: 15.0
+  focal_slope: 0.40000001
+  horiz_offset_correction: 0.025999999
+  laser_id: 4
+  min_intensity: 30
+  rot_correction: -0.00095355016485159
+  two_pt_correction_available: true
+  vert_correction: -0.1144967440141401
+  vert_offset_correction: 0.21484217000000003
+- dist_correction: 1.3536626999999999
+  dist_correction_x: 1.3909094
+  dist_correction_y: 1.3700326999999999
+  focal_distance: 17.0
+  focal_slope: 1.45
+  horiz_offset_correction: -0.025999999
+  laser_id: 5
+  min_intensity: 30
+  rot_correction: 0.03824387099052699
+  two_pt_correction_available: true
+  vert_correction: -0.10803612329921503
+  vert_offset_correction: 0.21437181
+- dist_correction: 1.4117873
+  dist_correction_x: 1.4350795
+  dist_correction_y: 1.3829624999999999
+  focal_distance: 10.5
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 6
+  min_intensity: 10
+  rot_correction: -0.015297255529962315
+  two_pt_correction_available: true
+  vert_correction: -0.14944538101702426
+  vert_offset_correction: 0.21739968999999998
+- dist_correction: 1.4269646
+  dist_correction_x: 1.451161
+  dist_correction_y: 1.4328421
+  focal_distance: 14.0
+  focal_slope: 1.3
+  horiz_offset_correction: -0.025999999
+  laser_id: 7
+  min_intensity: 10
+  rot_correction: 0.024255809272700053
+  two_pt_correction_available: true
+  vert_correction: -0.14344353231329066
+  vert_offset_correction: 0.21695873
+- dist_correction: 1.3808284000000002
+  dist_correction_x: 1.421472
+  dist_correction_y: 1.3838283000000002
+  focal_distance: 15.0
+  focal_slope: 0.94999999
+  horiz_offset_correction: 0.025999999
+  laser_id: 8
+  min_intensity: 30
+  rot_correction: 0.07354442571180776
+  two_pt_correction_available: true
+  vert_correction: -0.10278016723125998
+  vert_offset_correction: 0.21398966000000003
+- dist_correction: 1.3644336000000001
+  dist_correction_x: 1.3931616
+  dist_correction_y: 1.3852122
+  focal_distance: 12.5
+  focal_slope: 1.95
+  horiz_offset_correction: -0.025999999
+  laser_id: 9
+  min_intensity: 10
+  rot_correction: 0.11317857886058363
+  two_pt_correction_available: true
+  vert_correction: -0.09569590023202451
+  vert_offset_correction: 0.21347521
+- dist_correction: 1.4102663000000002
+  dist_correction_x: 1.4163402
+  dist_correction_y: 1.3592377
+  focal_distance: 12.5
+  focal_slope: 1.95
+  horiz_offset_correction: 0.025999999
+  laser_id: 10
+  min_intensity: 10
+  rot_correction: 0.05954228616823424
+  two_pt_correction_available: true
+  vert_correction: -0.1386345201601863
+  vert_offset_correction: 0.21660597
+- dist_correction: 1.5019737000000002
+  dist_correction_x: 1.532475
+  dist_correction_y: 1.5237663000000001
+  focal_distance: 13.0
+  focal_slope: 1.9
+  horiz_offset_correction: -0.025999999
+  laser_id: 11
+  min_intensity: 10
+  rot_correction: 0.09906092120980835
+  two_pt_correction_available: true
+  vert_correction: -0.13181073657049397
+  vert_offset_correction: 0.21610622
+- dist_correction: 1.4399905000000002
+  dist_correction_x: 1.4887962
+  dist_correction_y: 1.4455237
+  focal_distance: 14.5
+  focal_slope: 1.7
+  horiz_offset_correction: 0.025999999
+  laser_id: 12
+  max_intensity: 235
+  rot_correction: -0.07574798243226695
+  two_pt_correction_available: true
+  vert_correction: -0.054438932963427306
+  vert_offset_correction: 0.21049141
+- dist_correction: 1.5207593
+  dist_correction_x: 1.5401453
+  dist_correction_y: 1.5190082
+  focal_distance: 20.5
+  focal_slope: 1.25
+  horiz_offset_correction: -0.025999999
+  laser_id: 13
+  max_intensity: 240
+  rot_correction: -0.037047761947550245
+  two_pt_correction_available: true
+  vert_correction: -0.048730533448148504
+  vert_offset_correction: 0.21007986
+- dist_correction: 1.4746239
+  dist_correction_x: 1.5300989999999999
+  dist_correction_y: 1.4663734
+  focal_distance: 12.5
+  focal_slope: 1.9
+  horiz_offset_correction: 0.025999999
+  laser_id: 14
+  max_intensity: 245
+  rot_correction: -0.0895955468906376
+  two_pt_correction_available: true
+  vert_correction: -0.08961595328025192
+  vert_offset_correction: 0.21303425
+- dist_correction: 1.4697629
+  dist_correction_x: 1.5051735
+  dist_correction_y: 1.4558601
+  focal_distance: 19.5
+  focal_slope: 0.94999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 15
+  max_intensity: 245
+  rot_correction: -0.05072966149865084
+  two_pt_correction_available: true
+  vert_correction: -0.0839353306800186
+  vert_offset_correction: 0.21262267999999998
+- dist_correction: 1.4143376
+  dist_correction_x: 1.4432597000000003
+  dist_correction_y: 1.4038483
+  focal_distance: 24.0
+  focal_slope: 0.69999999
+  horiz_offset_correction: 0.025999999
+  laser_id: 16
+  max_intensity: 245
+  rot_correction: -0.001864320564407547
+  two_pt_correction_available: true
+  vert_correction: -0.043427018903405855
+  vert_offset_correction: 0.20969770000000001
+- dist_correction: 1.4815961
+  dist_correction_x: 1.5173615
+  dist_correction_y: 1.4871606
+  focal_distance: 14.5
+  focal_slope: 1.65
+  horiz_offset_correction: -0.025999999
+  laser_id: 17
+  rot_correction: 0.03747852840556422
+  two_pt_correction_available: true
+  vert_correction: -0.03648801216715539
+  vert_offset_correction: 0.20919794
+- dist_correction: 1.420331
+  dist_correction_x: 1.4755219
+  dist_correction_y: 1.3919118000000001
+  focal_distance: 17.5
+  focal_slope: 1.4
+  horiz_offset_correction: 0.025999999
+  laser_id: 18
+  rot_correction: -0.015194972429011364
+  two_pt_correction_available: true
+  vert_correction: -0.07906187922560139
+  vert_offset_correction: 0.21226994000000002
+- dist_correction: 1.4900717
+  dist_correction_x: 1.5143349000000002
+  dist_correction_y: 1.4829907
+  focal_distance: 24.0
+  focal_slope: 1.25
+  horiz_offset_correction: -0.025999999
+  laser_id: 19
+  rot_correction: 0.02391977928648433
+  two_pt_correction_available: true
+  vert_correction: -0.07255814015150577
+  vert_offset_correction: 0.21179958
+- dist_correction: 1.4823865
+  dist_correction_x: 1.5357741999999999
+  dist_correction_y: 1.4956403
+  focal_distance: 24.0
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 20
+  rot_correction: 0.07264374331532833
+  two_pt_correction_available: true
+  vert_correction: -0.031587736747464255
+  vert_offset_correction: 0.20884519999999998
+- dist_correction: 1.5553201
+  dist_correction_x: 1.5698593
+  dist_correction_y: 1.5624425
+  focal_distance: 15.5
+  focal_slope: 1.55
+  horiz_offset_correction: -0.025999999
+  laser_id: 21
+  rot_correction: 0.11143265968730214
+  two_pt_correction_available: true
+  vert_correction: -0.025460288914769372
+  vert_offset_correction: 0.20840424
+- dist_correction: 1.4437845999999999
+  dist_correction_x: 1.4909378000000002
+  dist_correction_y: 1.4347861
+  focal_distance: 20.5
+  focal_slope: 1.2
+  horiz_offset_correction: 0.025999999
+  laser_id: 22
+  rot_correction: 0.05942554283989759
+  two_pt_correction_available: true
+  vert_correction: -0.06665878416276627
+  vert_offset_correction: 0.21137333000000003
+- dist_correction: 1.4939513
+  dist_correction_x: 1.5194868
+  dist_correction_y: 1.5106346
+  focal_distance: 14.5
+  focal_slope: 1.65
+  horiz_offset_correction: -0.025999999
+  laser_id: 23
+  rot_correction: 0.09797042203986979
+  two_pt_correction_available: true
+  vert_correction: -0.06055112836378901
+  vert_offset_correction: 0.21093236999999998
+- dist_correction: 1.4521244999999998
+  dist_correction_x: 1.4884882
+  dist_correction_y: 1.4649333
+  focal_distance: 11.5
+  focal_slope: 2.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 24
+  rot_correction: -0.07658879305408597
+  two_pt_correction_available: true
+  vert_correction: 0.015620435355027301
+  vert_offset_correction: 0.20544985000000002
+- dist_correction: 1.5351622
+  dist_correction_x: 1.524973
+  dist_correction_y: 1.5029565
+  focal_distance: 18.5
+  focal_slope: 1.25
+  horiz_offset_correction: -0.025999999
+  laser_id: 25
+  rot_correction: -0.0379098725675606
+  two_pt_correction_available: true
+  vert_correction: 0.022567997346205196
+  vert_offset_correction: 0.20495010000000002
+- dist_correction: 1.5321327
+  dist_correction_x: 1.5833431999999998
+  dist_correction_y: 1.5359726
+  focal_distance: 13.0
+  focal_slope: 1.9
+  horiz_offset_correction: 0.025999999
+  laser_id: 26
+  rot_correction: -0.0904730670226138
+  two_pt_correction_available: true
+  vert_correction: -0.019943931467746017
+  vert_offset_correction: 0.20800737000000002
+- dist_correction: 1.5166023000000002
+  dist_correction_x: 1.4874829
+  dist_correction_y: 1.4625635
+  focal_distance: 21.5
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 27
+  rot_correction: -0.051308328902808065
+  two_pt_correction_available: true
+  vert_correction: -0.013200099491225388
+  vert_offset_correction: 0.20752234000000003
+- dist_correction: 1.4549194
+  dist_correction_x: 1.4688664
+  dist_correction_y: 1.4194371000000001
+  focal_distance: 13.5
+  focal_slope: 1.83
+  horiz_offset_correction: 0.025999999
+  laser_id: 28
+  rot_correction: -0.0019143155208309244
+  two_pt_correction_available: true
+  vert_correction: 0.027266617424120905
+  vert_offset_correction: 0.20461203000000003
+- dist_correction: 1.5617532
+  dist_correction_x: 1.5887217999999999
+  dist_correction_y: 1.5643922000000001
+  focal_distance: 18.5
+  focal_slope: 1.35
+  horiz_offset_correction: -0.025999999
+  laser_id: 29
+  rot_correction: 0.03681404490741569
+  two_pt_correction_available: true
+  vert_correction: 0.03421014630846329
+  vert_offset_correction: 0.20411228
+- dist_correction: 1.5132924
+  dist_correction_x: 1.5661812000000002
+  dist_correction_y: 1.5102689
+  focal_distance: 18.5
+  focal_slope: 1.35
+  horiz_offset_correction: 0.025999999
+  laser_id: 30
+  rot_correction: -0.015542064486559148
+  two_pt_correction_available: true
+  vert_correction: -0.007885903531460533
+  vert_offset_correction: 0.20714018
+- dist_correction: 1.5638524
+  dist_correction_x: 1.5621136000000002
+  dist_correction_y: 1.5383017
+  focal_distance: 21.5
+  focal_slope: 1.15
+  horiz_offset_correction: -0.025999999
+  laser_id: 31
+  rot_correction: 0.023284423588222334
+  two_pt_correction_available: true
+  vert_correction: -0.0015491891506552067
+  vert_offset_correction: 0.20668451000000002
+- dist_correction: 1.3077792
+  dist_correction_x: 1.3433452
+  dist_correction_y: 1.2840973
+  focal_distance: 10.5
+  focal_slope: 2.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 32
+  rot_correction: -0.1278634161583795
+  two_pt_correction_available: true
+  vert_correction: -0.39021216204755743
+  vert_offset_correction: 0.15970787
+- dist_correction: 1.4303885
+  dist_correction_x: 1.4429931999999999
+  dist_correction_y: 1.4607234
+  focal_distance: 0.25
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 33
+  rot_correction: -0.066528586091226
+  two_pt_correction_available: true
+  vert_correction: -0.38355018793281753
+  vert_offset_correction: 0.15922519
+- dist_correction: 1.3746819
+  dist_correction_x: 1.3873923
+  dist_correction_y: 1.4089924999999999
+  focal_distance: 0.25
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 34
+  rot_correction: 0.08854290740283328
+  two_pt_correction_available: true
+  vert_correction: -0.197138848550284
+  vert_offset_correction: 0.14656122
+- dist_correction: 1.3814778
+  dist_correction_x: 1.3932765
+  dist_correction_y: 1.4301869
+  focal_distance: 11.0
+  focal_slope: 2.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 35
+  rot_correction: 0.14547956884148489
+  two_pt_correction_available: true
+  vert_correction: -0.18768579625563228
+  vert_offset_correction: 0.14595152
+- dist_correction: 1.4313307
+  dist_correction_x: 1.4734517
+  dist_correction_y: 1.4390849000000001
+  focal_distance: 9.5
+  focal_slope: 1.85
+  horiz_offset_correction: 0.025999999
+  laser_id: 36
+  rot_correction: -0.005071588212420635
+  two_pt_correction_available: true
+  vert_correction: -0.3750836655445631
+  vert_offset_correction: 0.15861549
+- dist_correction: 1.3414835
+  dist_correction_x: 1.3820609
+  dist_correction_y: 1.355589
+  focal_distance: 9.5
+  focal_slope: 1.4
+  horiz_offset_correction: -0.025999999
+  laser_id: 37
+  rot_correction: 0.05427589303135225
+  two_pt_correction_available: true
+  vert_correction: -0.36762882325722723
+  vert_offset_correction: 0.15808201
+- dist_correction: 1.4895827
+  dist_correction_x: 1.5283238000000001
+  dist_correction_y: 1.4803529
+  focal_distance: 9.0
+  focal_slope: 1.65
+  horiz_offset_correction: 0.025999999
+  laser_id: 38
+  rot_correction: -0.028143856558087547
+  two_pt_correction_available: true
+  vert_correction: -0.4285668719175616
+  vert_offset_correction: 0.16254044
+- dist_correction: 1.3727733000000002
+  dist_correction_x: 1.3623596
+  dist_correction_y: 1.392661
+  focal_distance: 0.25
+  focal_slope: 1.15
+  horiz_offset_correction: -0.025999999
+  laser_id: 39
+  rot_correction: 0.03172272051181349
+  two_pt_correction_available: true
+  vert_correction: -0.4214410765541042
+  vert_offset_correction: 0.16200695
+- dist_correction: 1.4348983999999998
+  dist_correction_x: 1.4775407000000003
+  dist_correction_y: 1.4712174999999998
+  focal_distance: 0.25
+  focal_slope: 0.92000002
+  horiz_offset_correction: 0.025999999
+  laser_id: 40
+  rot_correction: 0.11411698480351568
+  two_pt_correction_available: true
+  vert_correction: -0.3565455112681652
+  vert_offset_correction: 0.15729448
+- dist_correction: 1.335618
+  dist_correction_x: 1.3519691
+  dist_correction_y: 1.3315152000000001
+  focal_distance: 11.200000000000001
+  focal_slope: 2.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 41
+  rot_correction: 0.1735498527902839
+  two_pt_correction_available: true
+  vert_correction: -0.34717860842539194
+  vert_offset_correction: 0.15663397
+- dist_correction: 1.4905824
+  dist_correction_x: 1.488313
+  dist_correction_y: 1.4948479000000001
+  focal_distance: 0.25
+  focal_slope: 1.1
+  horiz_offset_correction: 0.025999999
+  laser_id: 42
+  rot_correction: 0.09564756333839054
+  two_pt_correction_available: true
+  vert_correction: -0.4110102035460227
+  vert_offset_correction: 0.16123213
+- dist_correction: 1.3288423
+  dist_correction_x: 1.3409723
+  dist_correction_y: 1.3440451
+  focal_distance: 10.0
+  focal_slope: 1.95
+  horiz_offset_correction: -0.025999999
+  laser_id: 43
+  rot_correction: 0.15538288292189534
+  two_pt_correction_available: true
+  vert_correction: -0.40083030888437793
+  vert_offset_correction: 0.16048269
+- dist_correction: 1.3771290999999999
+  dist_correction_x: 1.3773239000000002
+  dist_correction_y: 1.3497290000000002
+  focal_distance: 11.5
+  focal_slope: 2.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 44
+  rot_correction: -0.12413605610123538
+  two_pt_correction_available: true
+  vert_correction: -0.2840315837972709
+  vert_offset_correction: 0.15228986
+- dist_correction: 1.3367807
+  dist_correction_x: 1.370152
+  dist_correction_y: 1.370934
+  focal_distance: 0.25
+  focal_slope: 0.44999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 45
+  rot_correction: -0.06413447432303407
+  two_pt_correction_available: true
+  vert_correction: -0.27761533458791926
+  vert_offset_correction: 0.15185799
+- dist_correction: 1.4788651
+  dist_correction_x: 1.5014308
+  dist_correction_y: 1.4727454
+  focal_distance: 11.5
+  focal_slope: 2.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 46
+  rot_correction: -0.14872602785785152
+  two_pt_correction_available: true
+  vert_correction: -0.3359268721635124
+  vert_offset_correction: 0.15584644
+- dist_correction: 1.3220766000000002
+  dist_correction_x: 1.3654865
+  dist_correction_y: 1.3739757000000001
+  focal_distance: 0.25
+  focal_slope: 0.94999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 47
+  rot_correction: -0.08707280959256145
+  two_pt_correction_available: true
+  vert_correction: -0.33026751989087316
+  vert_offset_correction: 0.15545268
+- dist_correction: 1.4612433999999999
+  dist_correction_x: 1.5250436
+  dist_correction_y: 1.4817635999999998
+  focal_distance: 13.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 48
+  rot_correction: -0.006799911150716457
+  two_pt_correction_available: true
+  vert_correction: -0.26851710773019805
+  vert_offset_correction: 0.15124829
+- dist_correction: 1.3407353000000002
+  dist_correction_x: 1.3478844
+  dist_correction_y: 1.3154279
+  focal_distance: 13.5
+  focal_slope: 1.8
+  horiz_offset_correction: -0.025999999
+  laser_id: 49
+  rot_correction: 0.05242808851765633
+  two_pt_correction_available: true
+  vert_correction: -0.26051854302098837
+  vert_offset_correction: 0.1507148
+- dist_correction: 1.3465115
+  dist_correction_x: 1.3874431999999999
+  dist_correction_y: 1.3508052000000002
+  focal_distance: 12.0
+  focal_slope: 1.85
+  horiz_offset_correction: 0.025999999
+  laser_id: 50
+  rot_correction: -0.028383715411859876
+  two_pt_correction_available: true
+  vert_correction: -0.3216451745070007
+  vert_offset_correction: 0.15485568000000002
+- dist_correction: 1.3629696999999998
+  dist_correction_x: 1.4037315000000001
+  dist_correction_y: 1.3869237
+  focal_distance: 12.0
+  focal_slope: 1.1
+  horiz_offset_correction: -0.025999999
+  laser_id: 51
+  rot_correction: 0.031843273893907245
+  two_pt_correction_available: true
+  vert_correction: -0.3135280670349956
+  vert_offset_correction: 0.15429679000000002
+- dist_correction: 1.4472754
+  dist_correction_x: 1.4817390000000001
+  dist_correction_y: 1.4782272
+  focal_distance: 2.0
+  focal_slope: 1.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 52
+  rot_correction: 0.10955275158734502
+  two_pt_correction_available: true
+  vert_correction: -0.24941678290173272
+  vert_offset_correction: 0.14997807999999999
+- dist_correction: 1.3800671
+  dist_correction_x: 1.3796414
+  dist_correction_y: 1.3943782
+  focal_distance: 11.200000000000001
+  focal_slope: 2.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 53
+  rot_correction: 0.16876716543828738
+  two_pt_correction_available: true
+  vert_correction: -0.2409525119882134
+  vert_offset_correction: 0.14941919
+- dist_correction: 1.5190169
+  dist_correction_x: 1.5619051
+  dist_correction_y: 1.5511705
+  focal_distance: 2.5
+  focal_slope: 1.05
+  horiz_offset_correction: 0.025999999
+  laser_id: 54
+  rot_correction: 0.09037283276367176
+  two_pt_correction_available: true
+  vert_correction: -0.30313513748485243
+  vert_offset_correction: 0.15358547
+- dist_correction: 1.3803656000000002
+  dist_correction_x: 1.3960698
+  dist_correction_y: 1.386106
+  focal_distance: 12.5
+  focal_slope: 1.9
+  horiz_offset_correction: -0.025999999
+  laser_id: 55
+  rot_correction: 0.14871534295217081
+  two_pt_correction_available: true
+  vert_correction: -0.29323634555253386
+  vert_offset_correction: 0.15291226
+- dist_correction: 1.5827696
+  dist_correction_x: 1.6050609
+  dist_correction_y: 1.5844797
+  focal_distance: 10.0
+  focal_slope: 1.95
+  horiz_offset_correction: 0.025999999
+  laser_id: 56
+  rot_correction: -0.12100867217308608
+  two_pt_correction_available: true
+  vert_correction: -0.17760463486977288
+  vert_offset_correction: 0.14530372
+- dist_correction: 1.3843919
+  dist_correction_x: 1.3915251000000002
+  dist_correction_y: 1.4156927
+  focal_distance: 0.25
+  focal_slope: 0.94999999
+  horiz_offset_correction: -0.025999999
+  laser_id: 57
+  rot_correction: -0.06431965899265843
+  two_pt_correction_available: true
+  vert_correction: -0.17006926832673774
+  vert_offset_correction: 0.14482104
+- dist_correction: 1.5491273
+  dist_correction_x: 1.5298964000000002
+  dist_correction_y: 1.5107637
+  focal_distance: 11.5
+  focal_slope: 2.0
+  horiz_offset_correction: 0.025999999
+  laser_id: 58
+  rot_correction: -0.14486168214370612
+  two_pt_correction_available: true
+  vert_correction: -0.22974121500510264
+  vert_offset_correction: 0.14868247
+- dist_correction: 1.3646004
+  dist_correction_x: 1.3803583000000001
+  dist_correction_y: 1.4061511
+  focal_distance: 0.25
+  focal_slope: 1.0
+  horiz_offset_correction: -0.025999999
+  laser_id: 59
+  rot_correction: -0.0852480451703211
+  two_pt_correction_available: true
+  vert_correction: -0.22391891879349718
+  vert_offset_correction: 0.14830141
+- dist_correction: 1.5239935
+  dist_correction_x: 1.560786
+  dist_correction_y: 1.5632524
+  focal_distance: 5.0
+  focal_slope: 1.15
+  horiz_offset_correction: 0.025999999
+  laser_id: 60
+  rot_correction: -0.005967226432828876
+  two_pt_correction_available: true
+  vert_correction: -0.16231529056824404
+  vert_offset_correction: 0.14432566
+- dist_correction: 1.4112029000000001
+  dist_correction_x: 1.4223886
+  dist_correction_y: 1.4542918
+  focal_distance: 2.5
+  focal_slope: 1.05
+  horiz_offset_correction: -0.025999999
+  laser_id: 61
+  rot_correction: 0.050600613599087636
+  two_pt_correction_available: true
+  vert_correction: -0.15314424682880032
+  vert_offset_correction: 0.14374136
+- dist_correction: 1.5013637
+  dist_correction_x: 1.5208610999999999
+  dist_correction_y: 1.5006433000000001
+  focal_distance: 16.5
+  focal_slope: 1.25
+  horiz_offset_correction: 0.025999999
+  laser_id: 62
+  rot_correction: -0.027436902217920986
+  two_pt_correction_available: true
+  vert_correction: -0.21457119711920336
+  vert_offset_correction: 0.14769171
+- dist_correction: 1.4423058
+  dist_correction_x: 1.4454633000000001
+  dist_correction_y: 1.4321198000000002
+  focal_distance: 9.0
+  focal_slope: 1.45
+  horiz_offset_correction: -0.025999999
+  laser_id: 63
+  rot_correction: 0.0290479702718764
+  two_pt_correction_available: true
+  vert_correction: -0.2079266762969834
+  vert_offset_correction: 0.14725984
+num_lasers: 64
+

--- a/velodyne_pointcloud/params/64e_utexas.yaml
+++ b/velodyne_pointcloud/params/64e_utexas.yaml
@@ -1,259 +1,772 @@
-# University of Texas HDL-64E calibration parameters
-lasers:
-- {dist_correction: 0.100000001490116, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 0, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0698131695389748, two_pt_correction_available: false, vert_correction: -0.124932751059532,
-  vert_offset_correction: 0}
-- {dist_correction: 0.280000001192093, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 1, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0392699092626572, two_pt_correction_available: false, vert_correction: -0.118993431329727,
-  vert_offset_correction: 0}
-- {dist_correction: 0.319999992847443, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 2, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0698131695389748, two_pt_correction_available: false, vert_correction: 0.0055470340885222,
-  vert_offset_correction: 0}
-- {dist_correction: 0.230000004172325, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 3, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.104719758033752, two_pt_correction_available: false, vert_correction: 0.0114863449707627,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0700000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 4, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.013962633907795, two_pt_correction_available: false, vert_correction: -0.113056324422359,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0900000035762787, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 5, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0392699092626572, two_pt_correction_available: false, vert_correction: -0.107121199369431,
-  vert_offset_correction: 0}
-- {dist_correction: 0.119999997317791, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 6, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0, two_pt_correction_available: false, vert_correction: -0.148716226220131,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 7, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0226892791688442, two_pt_correction_available: false, vert_correction: -0.142765983939171,
-  vert_offset_correction: 0}
-- {dist_correction: 0.129999995231628, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 8, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0820304751396179, two_pt_correction_available: false, vert_correction: -0.101187855005264,
-  vert_offset_correction: 0}
-- {dist_correction: 0.159999996423721, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 9, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.113446399569511, two_pt_correction_available: false, vert_correction: -0.0952560678124428,
-  vert_offset_correction: 0}
-- {dist_correction: 0.159999996423721, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 10, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0698131695389748, two_pt_correction_available: false, vert_correction: -0.136818811297417,
-  vert_offset_correction: 0}
-- {dist_correction: 0.159999996423721, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 11, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.104719758033752, two_pt_correction_available: false, vert_correction: -0.130874469876289,
-  vert_offset_correction: 0}
-- {dist_correction: 0.129999995231628, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 12, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.068067841231823, two_pt_correction_available: false, vert_correction: -0.05375986546278,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 13, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0349065847694874, two_pt_correction_available: false, vert_correction: -0.0478330813348293,
-  vert_offset_correction: 0}
-- {dist_correction: 0.170000001788139, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 14, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0837758108973503, two_pt_correction_available: false, vert_correction: -0.0893256440758705,
-  vert_offset_correction: 0}
-- {dist_correction: 0.239999994635582, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 15, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0479965545237064, two_pt_correction_available: false, vert_correction: -0.0833963677287102,
-  vert_offset_correction: 0}
-- {dist_correction: 0.180000007152557, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 16, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.00872664619237185, two_pt_correction_available: false, vert_correction: -0.0419059917330742,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0599999986588955, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 17, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0392699092626572, two_pt_correction_available: false, vert_correction: -0.035978376865387,
-  vert_offset_correction: 0}
-- {dist_correction: 0.140000000596046, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 18, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0, two_pt_correction_available: false, vert_correction: -0.0774680152535439,
-  vert_offset_correction: 0}
-- {dist_correction: 0.150000005960464, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 19, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0305432621389627, two_pt_correction_available: false, vert_correction: -0.0715404152870178,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 20, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0855211317539215, two_pt_correction_available: false, vert_correction: -0.0300500374287367,
-  vert_offset_correction: 0}
-- {dist_correction: 0.140000000596046, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 21, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.109083078801632, two_pt_correction_available: false, vert_correction: -0.024120757356286,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0799999982118607, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 22, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0698131695389748, two_pt_correction_available: false, vert_correction: -0.0656133219599724,
-  vert_offset_correction: 0}
-- {dist_correction: 0.159999996423721, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 23, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.104719758033752, two_pt_correction_available: false, vert_correction: -0.0596865378320217,
-  vert_offset_correction: 0}
-- {dist_correction: 0.119999997317791, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 24, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0610865242779255, two_pt_correction_available: false, vert_correction: 0.0174280721694231,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 25, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0349065847694874, two_pt_correction_available: false, vert_correction: 0.0233724191784859,
-  vert_offset_correction: 0}
-- {dist_correction: 0.159999996423721, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 26, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0785398185253143, two_pt_correction_available: false, vert_correction: -0.0181903336197138,
-  vert_offset_correction: 0}
-- {dist_correction: 0.259999990463257, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 27, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0471238903701305, two_pt_correction_available: false, vert_correction: -0.0122585473582149,
-  vert_offset_correction: 0}
-- {dist_correction: 0.140000000596046, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 28, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0104719763621688, two_pt_correction_available: false, vert_correction: 0.0293195936828852,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 29, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0349065847694874, two_pt_correction_available: false, vert_correction: 0.0352698266506195,
-  vert_offset_correction: 0}
-- {dist_correction: 0.209999993443489, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 30, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.00436332309618592, two_pt_correction_available: false, vert_correction: -0.00632520206272602,
-  vert_offset_correction: 0}
-- {dist_correction: 0.140000000596046, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 31, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0296705979853868, two_pt_correction_available: false, vert_correction: -0.000390077300835401,
-  vert_offset_correction: 0}
-- {dist_correction: 0.119999997317791, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 32, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.122173048555851, two_pt_correction_available: false, vert_correction: -0.396850973367691,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0199999995529652, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 33, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0610865242779255, two_pt_correction_available: false, vert_correction: -0.387918144464493,
-  vert_offset_correction: 0}
-- {dist_correction: 0.100000001490116, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 34, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0959931090474129, two_pt_correction_available: false, vert_correction: -0.200955957174301,
-  vert_offset_correction: 0}
-- {dist_correction: 0.230000004172325, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 35, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.148352980613708, two_pt_correction_available: false, vert_correction: -0.192023113369942,
-  vert_offset_correction: 0}
-- {dist_correction: 0.170000001788139, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 36, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.00872664619237185, two_pt_correction_available: false, vert_correction: -0.378992766141891,
-  vert_offset_correction: 0}
-- {dist_correction: 0.150000005960464, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 37, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0610865242779255, two_pt_correction_available: false, vert_correction: -0.370074152946472,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0500000007450581, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 38, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0174532923847437, two_pt_correction_available: false, vert_correction: -0.43128889799118,
-  vert_offset_correction: 0}
-- {dist_correction: 0.270000010728836, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 39, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0349065847694874, two_pt_correction_available: false, vert_correction: -0.423701733350754,
-  vert_offset_correction: 0}
-- {dist_correction: 0.180000007152557, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 40, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.122173048555851, two_pt_correction_available: false, vert_correction: -0.361161530017853,
-  vert_offset_correction: 0}
-- {dist_correction: 0.189999997615814, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 41, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.174532920122147, two_pt_correction_available: false, vert_correction: -0.352254241704941,
-  vert_offset_correction: 0}
-- {dist_correction: 0.100000001490116, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 42, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.104719758033752, two_pt_correction_available: false, vert_correction: -0.414742022752762,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 43, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.165806278586388, two_pt_correction_available: false, vert_correction: -0.405792057514191,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 44, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.113446399569511, two_pt_correction_available: false, vert_correction: -0.28999200463295,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 45, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0567231997847557, two_pt_correction_available: false, vert_correction: -0.281101644039154,
-  vert_offset_correction: 0}
-- {dist_correction: 0.150000005960464, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 46, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.13962633907795, two_pt_correction_available: false, vert_correction: -0.343351542949677,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 47, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0872664600610733, two_pt_correction_available: false, vert_correction: -0.334452718496323,
-  vert_offset_correction: 0}
-- {dist_correction: 0.0599999986588955, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 48, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0, two_pt_correction_available: false, vert_correction: -0.272210210561752,
-  vert_offset_correction: 0}
-- {dist_correction: 0.129999995231628, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 49, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0558505356311798, two_pt_correction_available: false, vert_correction: -0.26331701874733,
-  vert_offset_correction: 0}
-- {dist_correction: 0.00999999977648258, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 50, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0174532923847437, two_pt_correction_available: false, vert_correction: -0.323895305395126,
-  vert_offset_correction: 0}
-- {dist_correction: 0.150000005960464, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 51, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0349065847694874, two_pt_correction_available: false, vert_correction: -0.316663861274719,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 52, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.122173048555851, two_pt_correction_available: false, vert_correction: -0.254421383142471,
-  vert_offset_correction: 0}
-- {dist_correction: 0.239999994635582, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 53, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.165806278586388, two_pt_correction_available: false, vert_correction: -0.245522528886795,
-  vert_offset_correction: 0}
-- {dist_correction: 0.180000007152557, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 54, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.104719758033752, two_pt_correction_available: false, vert_correction: -0.307772427797318,
-  vert_offset_correction: 0}
-- {dist_correction: 0.219999998807907, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 55, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.157079637050629, two_pt_correction_available: false, vert_correction: -0.298882067203522,
-  vert_offset_correction: 0}
-- {dist_correction: 0.140000000596046, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 56, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.104719758033752, two_pt_correction_available: false, vert_correction: -0.183082059025764,
-  vert_offset_correction: 0}
-- {dist_correction: 0.319999992847443, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 57, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0610865242779255, two_pt_correction_available: false, vert_correction: -0.17413204908371,
-  vert_offset_correction: 0}
-- {dist_correction: 0.200000002980232, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 58, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.13962633907795, two_pt_correction_available: false, vert_correction: -0.236619830131531,
-  vert_offset_correction: 0}
-- {dist_correction: 0.25, dist_correction_x: 0, dist_correction_y: 0, focal_distance: 0,
-  focal_slope: 0, laser_id: 59, max_intensity: 255, min_intensity: 0, rot_correction: -0.0785398185253143,
-  two_pt_correction_available: false, vert_correction: -0.22771255671978, vert_offset_correction: 0}
-- {dist_correction: 0.170000001788139, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 60, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0, two_pt_correction_available: false, vert_correction: -0.16517236828804,
-  vert_offset_correction: 0}
-- {dist_correction: 0.230000004172325, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 61, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0436332300305367, two_pt_correction_available: false, vert_correction: -0.156202226877213,
-  vert_offset_correction: 0}
-- {dist_correction: 0.150000005960464, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 62, max_intensity: 255, min_intensity: 0,
-  rot_correction: -0.0174532923847437, two_pt_correction_available: false, vert_correction: -0.218799933791161,
-  vert_offset_correction: 0}
-- {dist_correction: 0.230000004172325, dist_correction_x: 0, dist_correction_y: 0,
-  focal_distance: 0, focal_slope: 0, laser_id: 63, max_intensity: 255, min_intensity: 0,
-  rot_correction: 0.0314159244298935, two_pt_correction_available: false, vert_correction: -0.209881335496902,
-  vert_offset_correction: 0}
-num_lasers: 64
 distance_resolution: 0.002
+lasers:
+- dist_correction: 0.100000001490116
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 0
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0698131695389748
+  two_pt_correction_available: true
+  vert_correction: -0.124932751059532
+  vert_offset_correction: 0
+- dist_correction: 0.280000001192093
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 1
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0392699092626572
+  two_pt_correction_available: true
+  vert_correction: -0.118993431329727
+  vert_offset_correction: 0
+- dist_correction: 0.319999992847443
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 2
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0698131695389748
+  two_pt_correction_available: true
+  vert_correction: 0.0055470340885222
+  vert_offset_correction: 0
+- dist_correction: 0.230000004172325
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 3
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: 0.0114863449707627
+  vert_offset_correction: 0
+- dist_correction: 0.0700000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 4
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.013962633907795
+  two_pt_correction_available: true
+  vert_correction: -0.113056324422359
+  vert_offset_correction: 0
+- dist_correction: 0.0900000035762787
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 5
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0392699092626572
+  two_pt_correction_available: true
+  vert_correction: -0.107121199369431
+  vert_offset_correction: 0
+- dist_correction: 0.119999997317791
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 6
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0
+  two_pt_correction_available: true
+  vert_correction: -0.148716226220131
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 7
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0226892791688442
+  two_pt_correction_available: true
+  vert_correction: -0.142765983939171
+  vert_offset_correction: 0
+- dist_correction: 0.129999995231628
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 8
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0820304751396179
+  two_pt_correction_available: true
+  vert_correction: -0.101187855005264
+  vert_offset_correction: 0
+- dist_correction: 0.159999996423721
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 9
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.113446399569511
+  two_pt_correction_available: true
+  vert_correction: -0.0952560678124428
+  vert_offset_correction: 0
+- dist_correction: 0.159999996423721
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 10
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0698131695389748
+  two_pt_correction_available: true
+  vert_correction: -0.136818811297417
+  vert_offset_correction: 0
+- dist_correction: 0.159999996423721
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 11
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: -0.130874469876289
+  vert_offset_correction: 0
+- dist_correction: 0.129999995231628
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 12
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.068067841231823
+  two_pt_correction_available: true
+  vert_correction: -0.05375986546278
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 13
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0349065847694874
+  two_pt_correction_available: true
+  vert_correction: -0.0478330813348293
+  vert_offset_correction: 0
+- dist_correction: 0.170000001788139
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 14
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0837758108973503
+  two_pt_correction_available: true
+  vert_correction: -0.0893256440758705
+  vert_offset_correction: 0
+- dist_correction: 0.239999994635582
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 15
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0479965545237064
+  two_pt_correction_available: true
+  vert_correction: -0.0833963677287102
+  vert_offset_correction: 0
+- dist_correction: 0.180000007152557
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 16
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.00872664619237185
+  two_pt_correction_available: true
+  vert_correction: -0.0419059917330742
+  vert_offset_correction: 0
+- dist_correction: 0.0599999986588955
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 17
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0392699092626572
+  two_pt_correction_available: true
+  vert_correction: -0.035978376865387
+  vert_offset_correction: 0
+- dist_correction: 0.140000000596046
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 18
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0
+  two_pt_correction_available: true
+  vert_correction: -0.0774680152535439
+  vert_offset_correction: 0
+- dist_correction: 0.150000005960464
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 19
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0305432621389627
+  two_pt_correction_available: true
+  vert_correction: -0.0715404152870178
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 20
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0855211317539215
+  two_pt_correction_available: true
+  vert_correction: -0.0300500374287367
+  vert_offset_correction: 0
+- dist_correction: 0.140000000596046
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 21
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.109083078801632
+  two_pt_correction_available: true
+  vert_correction: -0.024120757356286
+  vert_offset_correction: 0
+- dist_correction: 0.0799999982118607
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 22
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0698131695389748
+  two_pt_correction_available: true
+  vert_correction: -0.0656133219599724
+  vert_offset_correction: 0
+- dist_correction: 0.159999996423721
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 23
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: -0.0596865378320217
+  vert_offset_correction: 0
+- dist_correction: 0.119999997317791
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 24
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0610865242779255
+  two_pt_correction_available: true
+  vert_correction: 0.0174280721694231
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 25
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0349065847694874
+  two_pt_correction_available: true
+  vert_correction: 0.0233724191784859
+  vert_offset_correction: 0
+- dist_correction: 0.159999996423721
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 26
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0785398185253143
+  two_pt_correction_available: true
+  vert_correction: -0.0181903336197138
+  vert_offset_correction: 0
+- dist_correction: 0.259999990463257
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 27
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0471238903701305
+  two_pt_correction_available: true
+  vert_correction: -0.0122585473582149
+  vert_offset_correction: 0
+- dist_correction: 0.140000000596046
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 28
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0104719763621688
+  two_pt_correction_available: true
+  vert_correction: 0.0293195936828852
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 29
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0349065847694874
+  two_pt_correction_available: true
+  vert_correction: 0.0352698266506195
+  vert_offset_correction: 0
+- dist_correction: 0.209999993443489
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 30
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.00436332309618592
+  two_pt_correction_available: true
+  vert_correction: -0.00632520206272602
+  vert_offset_correction: 0
+- dist_correction: 0.140000000596046
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 31
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0296705979853868
+  two_pt_correction_available: true
+  vert_correction: -0.000390077300835401
+  vert_offset_correction: 0
+- dist_correction: 0.119999997317791
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 32
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.122173048555851
+  two_pt_correction_available: true
+  vert_correction: -0.396850973367691
+  vert_offset_correction: 0
+- dist_correction: 0.0199999995529652
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 33
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0610865242779255
+  two_pt_correction_available: true
+  vert_correction: -0.387918144464493
+  vert_offset_correction: 0
+- dist_correction: 0.100000001490116
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 34
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0959931090474129
+  two_pt_correction_available: true
+  vert_correction: -0.200955957174301
+  vert_offset_correction: 0
+- dist_correction: 0.230000004172325
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 35
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.148352980613708
+  two_pt_correction_available: true
+  vert_correction: -0.192023113369942
+  vert_offset_correction: 0
+- dist_correction: 0.170000001788139
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 36
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.00872664619237185
+  two_pt_correction_available: true
+  vert_correction: -0.378992766141891
+  vert_offset_correction: 0
+- dist_correction: 0.150000005960464
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 37
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0610865242779255
+  two_pt_correction_available: true
+  vert_correction: -0.370074152946472
+  vert_offset_correction: 0
+- dist_correction: 0.0500000007450581
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 38
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0174532923847437
+  two_pt_correction_available: true
+  vert_correction: -0.43128889799118
+  vert_offset_correction: 0
+- dist_correction: 0.270000010728836
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 39
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0349065847694874
+  two_pt_correction_available: true
+  vert_correction: -0.423701733350754
+  vert_offset_correction: 0
+- dist_correction: 0.180000007152557
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 40
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.122173048555851
+  two_pt_correction_available: true
+  vert_correction: -0.361161530017853
+  vert_offset_correction: 0
+- dist_correction: 0.189999997615814
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 41
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.174532920122147
+  two_pt_correction_available: true
+  vert_correction: -0.352254241704941
+  vert_offset_correction: 0
+- dist_correction: 0.100000001490116
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 42
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: -0.414742022752762
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 43
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.165806278586388
+  two_pt_correction_available: true
+  vert_correction: -0.405792057514191
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 44
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.113446399569511
+  two_pt_correction_available: true
+  vert_correction: -0.28999200463295
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 45
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0567231997847557
+  two_pt_correction_available: true
+  vert_correction: -0.281101644039154
+  vert_offset_correction: 0
+- dist_correction: 0.150000005960464
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 46
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.13962633907795
+  two_pt_correction_available: true
+  vert_correction: -0.343351542949677
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 47
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0872664600610733
+  two_pt_correction_available: true
+  vert_correction: -0.334452718496323
+  vert_offset_correction: 0
+- dist_correction: 0.0599999986588955
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 48
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0
+  two_pt_correction_available: true
+  vert_correction: -0.272210210561752
+  vert_offset_correction: 0
+- dist_correction: 0.129999995231628
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 49
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0558505356311798
+  two_pt_correction_available: true
+  vert_correction: -0.26331701874733
+  vert_offset_correction: 0
+- dist_correction: 0.00999999977648258
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 50
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0174532923847437
+  two_pt_correction_available: true
+  vert_correction: -0.323895305395126
+  vert_offset_correction: 0
+- dist_correction: 0.150000005960464
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 51
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0349065847694874
+  two_pt_correction_available: true
+  vert_correction: -0.316663861274719
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 52
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.122173048555851
+  two_pt_correction_available: true
+  vert_correction: -0.254421383142471
+  vert_offset_correction: 0
+- dist_correction: 0.239999994635582
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 53
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.165806278586388
+  two_pt_correction_available: true
+  vert_correction: -0.245522528886795
+  vert_offset_correction: 0
+- dist_correction: 0.180000007152557
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 54
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: -0.307772427797318
+  vert_offset_correction: 0
+- dist_correction: 0.219999998807907
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 55
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.157079637050629
+  two_pt_correction_available: true
+  vert_correction: -0.298882067203522
+  vert_offset_correction: 0
+- dist_correction: 0.140000000596046
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 56
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.104719758033752
+  two_pt_correction_available: true
+  vert_correction: -0.183082059025764
+  vert_offset_correction: 0
+- dist_correction: 0.319999992847443
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 57
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0610865242779255
+  two_pt_correction_available: true
+  vert_correction: -0.17413204908371
+  vert_offset_correction: 0
+- dist_correction: 0.200000002980232
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 58
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.13962633907795
+  two_pt_correction_available: true
+  vert_correction: -0.236619830131531
+  vert_offset_correction: 0
+- dist_correction: 0.25
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 59
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0785398185253143
+  two_pt_correction_available: true
+  vert_correction: -0.22771255671978
+  vert_offset_correction: 0
+- dist_correction: 0.170000001788139
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 60
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0
+  two_pt_correction_available: true
+  vert_correction: -0.16517236828804
+  vert_offset_correction: 0
+- dist_correction: 0.230000004172325
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 61
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0436332300305367
+  two_pt_correction_available: true
+  vert_correction: -0.156202226877213
+  vert_offset_correction: 0
+- dist_correction: 0.150000005960464
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 62
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: -0.0174532923847437
+  two_pt_correction_available: true
+  vert_correction: -0.218799933791161
+  vert_offset_correction: 0
+- dist_correction: 0.230000004172325
+  dist_correction_x: 0
+  dist_correction_y: 0
+  focal_distance: 0
+  focal_slope: 0
+  laser_id: 63
+  max_intensity: 255
+  min_intensity: 0
+  rot_correction: 0.0314159244298935
+  two_pt_correction_available: true
+  vert_correction: -0.209881335496902
+  vert_offset_correction: 0
+num_lasers: 64
+

--- a/velodyne_pointcloud/scripts/add_two_pt.py
+++ b/velodyne_pointcloud/scripts/add_two_pt.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+"""
+usage: add_two_pt.py < calibration.yaml > calibration_two_pt.yaml
+
+In order to take into acount *HDL-64* correction_{x,y}, related to 2012 merge:
+https://github.com/ros-drivers/velodyne/commit/f30d68735c47312aa73d29203ddb16abc01357f4
+
+https://github.com/ros-drivers/velodyne/blob/master/velodyne_pointcloud/src/lib/rawdata.cc#L438
+https://github.com/ros-drivers/velodyne/blob/master/velodyne_pointcloud/src/lib/calibration.cc#L70
+"""
+import sys
+import yaml
+
+calibration = yaml.safe_load(sys.stdin)
+for laser in calibration['lasers']:
+    laser['two_pt_correction_available'] = True
+
+print(yaml.safe_dump(calibration))

--- a/velodyne_pointcloud/scripts/gen_calibration.py
+++ b/velodyne_pointcloud/scripts/gen_calibration.py
@@ -199,6 +199,14 @@ elif calibration['num_lasers'] != num_enabled:
 # TODO: make sure all required fields are present.
 # (Which ones are required?)
 
+
+# fix #473 : take into acount HDL-64 correction_{x,y}, related to:
+#            commit/f30d68735c47312aa73d29203ddb16abc01357f4
+for laser in calibration['lasers']:
+    if laser.get('dist_correction_x', 0) and laser.get('dist_correction_y', 0):
+        laser['two_pt_correction_available'] = True
+
+
 if calibrationGood:
 
     # write calibration data to YAML file

--- a/velodyne_pointcloud/tests/test_calibration.cpp
+++ b/velodyne_pointcloud/tests/test_calibration.cpp
@@ -110,7 +110,7 @@ TEST(Calibration, hdl64e)
 
   // check some values for the first laser:
   LaserCorrection laser = calibration.laser_corrections[0];
-  EXPECT_FALSE(laser.two_pt_correction_available);
+  EXPECT_TRUE(laser.two_pt_correction_available);
   EXPECT_FLOAT_EQ(laser.vert_correction, -0.124932751059532);
   EXPECT_FLOAT_EQ(laser.horiz_offset_correction, 0.0);
   EXPECT_EQ(laser.max_intensity, 255);
@@ -118,7 +118,7 @@ TEST(Calibration, hdl64e)
 
   // check similar values for the last laser:
   laser = calibration.laser_corrections[63];
-  EXPECT_FALSE(laser.two_pt_correction_available);
+  EXPECT_TRUE(laser.two_pt_correction_available);
   EXPECT_FLOAT_EQ(laser.vert_correction, -0.209881335496902);
   EXPECT_FLOAT_EQ(laser.horiz_offset_correction, 0.0);
   EXPECT_EQ(laser.max_intensity, 255);
@@ -134,7 +134,7 @@ TEST(Calibration, hdl64e_s21)
 
   // check some values for the first laser:
   LaserCorrection laser = calibration.laser_corrections[0];
-  EXPECT_FALSE(laser.two_pt_correction_available);
+  EXPECT_TRUE(laser.two_pt_correction_available);
   EXPECT_FLOAT_EQ(laser.vert_correction, -0.15304134919741974);
   EXPECT_FLOAT_EQ(laser.horiz_offset_correction, 0.025999999);
   EXPECT_EQ(laser.max_intensity, 235);
@@ -142,7 +142,7 @@ TEST(Calibration, hdl64e_s21)
 
   // check similar values for the last laser:
   laser = calibration.laser_corrections[63];
-  EXPECT_FALSE(laser.two_pt_correction_available);
+  EXPECT_TRUE(laser.two_pt_correction_available);
   EXPECT_FLOAT_EQ(laser.vert_correction, -0.2106649408137298);
   EXPECT_FLOAT_EQ(laser.horiz_offset_correction, -0.025999999);
   EXPECT_EQ(laser.max_intensity, 255);


### PR DESCRIPTION
In order to take into account *HDL-64* correction_{x,y}, related to 2012 merge:

https://github.com/ros-drivers/velodyne/blob/1.7.0/velodyne_pointcloud/src/lib/rawdata.cc#L438
https://github.com/ros-drivers/velodyne/blob/1.7.0/velodyne_pointcloud/src/lib/calibration.cc#L70

see issues: #109 #295
and commit: f30d68735c47312aa73d29203ddb16abc01357f4