### PR TITLE
Feature/timestamp from phaselock angle

### DIFF
--- a/velodyne_driver/include/velodyne_driver/driver.h
+++ b/velodyne_driver/include/velodyne_driver/driver.h
@@ -74,15 +74,18 @@ private:
     int    npackets;                 // number of packets to collect
     double rpm;                      // device rotation rate (RPMs)
     int cut_angle;                   // cutting angle in 1/100°
+    int phase_lock_angle;            // configured phase lock angle
     double time_offset;              // time in seconds added to each velodyne time stamp
     bool enabled;                    // polling is enabled
     bool timestamp_first_packet;
+    bool timestamp_phase_lock;
   }
   config_;
 
   boost::shared_ptr<Input> input_;
   ros::Publisher output_;
   int last_azimuth_;
+  int phase_lock_angle_;
 
   /* diagnostics updater */
   ros::Timer diag_timer_;

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -16,7 +16,9 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
   <arg name="timestamp_first_packet" default="false" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="diagnostic_frequency_tolerance" default="0.1" />
 
   <!-- start nodelet manager -->
@@ -37,6 +39,8 @@
     <param name="gps_time" value="$(arg gps_time)"/>
     <param name="pcap_time" value="$(arg pcap_time)"/>
     <param name="cut_angle" value="$(arg cut_angle)"/>
+    <param name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <param name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <param name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
     <param name="diagnostic_frequency_tolerance" value="$(arg diagnostic_frequency_tolerance)"/>
   </node>

--- a/velodyne_pointcloud/launch/32e_points.launch
+++ b/velodyne_pointcloud/launch/32e_points.launch
@@ -19,6 +19,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -39,6 +41,8 @@
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <arg name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/64e_S3.launch
+++ b/velodyne_pointcloud/launch/64e_S3.launch
@@ -19,6 +19,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -39,6 +41,8 @@
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <arg name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/VLP-32C_points.launch
+++ b/velodyne_pointcloud/launch/VLP-32C_points.launch
@@ -19,6 +19,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -39,6 +41,8 @@
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <arg name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -19,6 +19,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -39,6 +41,8 @@
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <arg name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 

--- a/velodyne_pointcloud/launch/VLS128_points.launch
+++ b/velodyne_pointcloud/launch/VLS128_points.launch
@@ -18,6 +18,8 @@
   <arg name="rpm" default="600.0" />
   <arg name="gps_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="phase_lock_angle" default="-0.01" />
+  <arg name="timestamp_phase_lock" default="false" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -37,6 +39,8 @@
     <arg name="rpm" value="$(arg rpm)"/>
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="phase_lock_angle" value="$(arg phase_lock_angle)"/>
+    <arg name="timestamp_phase_lock" value="$(arg timestamp_phase_lock)"/>
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 


### PR DESCRIPTION
Adds the possibility to set the point cloud time stamp to the stamp of the package received when passing the phase_lock angle.
It is implemented similar to the cut_off angle and makes probably only sense to use both together. 

I tested it live with an VLP32-c

Addresses also #242 