### PR TITLE
roslint can be a test-depend

### DIFF
--- a/velodyne_driver/CMakeLists.txt
+++ b/velodyne_driver/CMakeLists.txt
@@ -10,7 +10,7 @@ elseif ("${CMAKE_CXX_STANDARD_COMPUTED_DEFAULT}" STREQUAL "98")
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
-set(${PROJECT_NAME}_CATKIN_DEPS 
+set(${PROJECT_NAME}_CATKIN_DEPS
     diagnostic_updater
     dynamic_reconfigure
     nodelet
@@ -18,7 +18,7 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     tf
     velodyne_msgs)
 
-find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS} roslint)
+find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS})
 
 # This driver uses Boost threads
 find_package(Boost REQUIRED COMPONENTS thread)
@@ -49,13 +49,13 @@ install(DIRECTORY launch/
 install(PROGRAMS src/vdump
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-roslint_cpp()
-
 if (CATKIN_ENABLE_TESTING)
-
   # these dependencies are only needed for unit testing
   find_package(roslaunch REQUIRED)
+  find_package(roslint REQUIRED)
   find_package(rostest REQUIRED)
+
+  roslint_cpp()
 
   # Download packet capture (PCAP) files containing test data.
   # Store them in devel-space, so rostest can easily find them.
@@ -74,7 +74,7 @@ if (CATKIN_ENABLE_TESTING)
     http://download.ros.org/data/velodyne/vlp16.pcap
     DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/tests
     MD5 f45c2bb1d7ee358274e423ea3b66fd73)
-  
+
   # unit tests
   add_rostest(tests/pcap_node_hertz.test)
   add_rostest(tests/pcap_nodelet_hertz.test)
@@ -82,7 +82,7 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest(tests/pcap_32e_nodelet_hertz.test)
   add_rostest(tests/pcap_vlp16_node_hertz.test)
   add_rostest(tests/pcap_vlp16_nodelet_hertz.test)
-  
+
   # parse check all the launch/*.launch files
   roslaunch_add_file_check(launch)
 

--- a/velodyne_driver/package.xml
+++ b/velodyne_driver/package.xml
@@ -19,8 +19,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslint</build_depend>
-
   <depend>diagnostic_updater</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>libpcap</depend>
@@ -30,6 +28,7 @@
   <depend>velodyne_msgs</depend>
 
   <test_depend>roslaunch</test_depend>
+  <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>


### PR DESCRIPTION
No need to have `roslint` actually ending up in production robots.