### PR TITLE
Update velodyne_pointcloud CMakeLists.txt export dependencies

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -151,10 +151,10 @@ endif()
 ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_dependencies(
   diagnostic_updater
-  eigen
+  Eigen3
   geometry_msgs
   message_filters
-  pcl
+  PCL
   rclcpp
   sensor_msgs
   tf2

--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -158,6 +158,7 @@ ament_export_dependencies(
   rclcpp
   sensor_msgs
   tf2
+  yaml-cpp
   tf2_ros
   velodyne_msgs
 )


### PR DESCRIPTION
Ament export requires the dependency names to match the names used in the `find_package` CMake command.  Resolves: https://github.com/ros-drivers/velodyne/issues/550