### PR TITLE
FOV cut functionality fix

### DIFF
--- a/velodyne_driver/include/velodyne_driver/driver.h
+++ b/velodyne_driver/include/velodyne_driver/driver.h
@@ -41,6 +41,7 @@
 
 #include <velodyne_driver/input.h>
 #include <velodyne_driver/VelodyneNodeConfig.h>
+#include <velodyne_msgs/VelodyneScan.h>
 
 namespace velodyne_driver
 {
@@ -65,6 +66,10 @@ private:
   // Pointer to dynamic reconfigure service srv_
   boost::shared_ptr<dynamic_reconfigure::Server<velodyne_driver::
               VelodyneNodeConfig> > srv_;
+  // Publish packets assigned to current scan
+  void publishScan(const velodyne_msgs::VelodyneScanPtr &scan);
+  // Helper function to determine if one value is between start and end value
+  bool isBetween(const int value, const int start, const int end) const;
 
   // configuration parameters
   struct
@@ -74,6 +79,7 @@ private:
     int    npackets;                 // number of packets to collect
     double rpm;                      // device rotation rate (RPMs)
     int cut_angle;                   // cutting angle in 1/100°
+    int fov_start_angle, fov_end_angle;  // FOV cut angles in 1/100°, < 0 if disabled
     double time_offset;              // time in seconds added to each velodyne time stamp
     bool enabled;                    // polling is enabled
     bool timestamp_first_packet;

--- a/velodyne_driver/launch/nodelet_manager.launch
+++ b/velodyne_driver/launch/nodelet_manager.launch
@@ -16,6 +16,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="fov_start_angle" default="-1" />
+  <arg name="fov_end_angle" default="-1" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="diagnostic_frequency_tolerance" default="0.1" />
 
@@ -37,6 +39,8 @@
     <param name="gps_time" value="$(arg gps_time)"/>
     <param name="pcap_time" value="$(arg pcap_time)"/>
     <param name="cut_angle" value="$(arg cut_angle)"/>
+    <param name="fov_start_angle" value="$(arg fov_start_angle)" />
+    <param name="fov_end_angle" value="$(arg fov_end_angle)" />
     <param name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
     <param name="diagnostic_frequency_tolerance" value="$(arg diagnostic_frequency_tolerance)"/>
   </node>

--- a/velodyne_pointcloud/launch/VLP16_points.launch
+++ b/velodyne_pointcloud/launch/VLP16_points.launch
@@ -19,6 +19,8 @@
   <arg name="gps_time" default="false" />
   <arg name="pcap_time" default="false" />
   <arg name="cut_angle" default="-0.01" />
+  <arg name="fov_start_angle" default="-1" />
+  <arg name="fov_end_angle" default="-1" />
   <arg name="timestamp_first_packet" default="false" />
   <arg name="laserscan_ring" default="-1" />
   <arg name="laserscan_resolution" default="0.007" />
@@ -39,6 +41,8 @@
     <arg name="gps_time" value="$(arg gps_time)"/>
     <arg name="pcap_time" value="$(arg pcap_time)"/>
     <arg name="cut_angle" value="$(arg cut_angle)"/>
+    <arg name="fov_start_angle" value="$(arg fov_start_angle)" />
+    <arg name="fov_end_angle" value="$(arg fov_end_angle)" />
     <arg name="timestamp_first_packet" value="$(arg timestamp_first_packet)"/>
   </include>
 


### PR DESCRIPTION
The previous version allowed only to set the `cut_angle` parameter cropping the FOV from 0 to n, which I find barely useful. Moreover, its implementation wasn't correct (it actually didn't cut the FOV at all). However, the Velodyne web interface allows for cutting FOV from MIN to MAX angle. This caused disproportion and reduction of publishing frequency.

_In my case, I needed to cut the FOV of LiDAR from 270 to 90 degrees. Doing so only in the web interface caused the LiDAR to send half number of packets. However, the ROS driver implementation computed `npackets` - expected number of packets in one scan assuming 0-360 deg. FOV - based on rotation frequency, then reads the packets from LiDAR in a for loop counting up to `npackets` value and only then sending out. As the LiDAR was sending only half of the FOV, the ROS driver would mix up packets from two revolutions together reducing the output frequency by half._

In this version, the FOV cut can by set either by `cut_angle` parameter cutting from 0 to n radians or by setting `fov_start_angle` and `fov_end_angle` parameters defining exact scan sector in degrees.
