### PR TITLE
[ros2] Fix parameter loading in launch files (VLP16, VLP32C, VLS128)Fix launch file params

### DIFF
--- a/velodyne_driver/launch/velodyne_driver_node-VLP16-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP16-launch.py
@@ -33,7 +33,7 @@
 """Launch the velodyne driver node with default configuration."""
 
 import os
-
+import yaml 
 import ament_index_python.packages
 import launch
 import launch_ros.actions
@@ -43,7 +43,11 @@ def generate_launch_description():
     config_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory('velodyne_driver'),
         'config')
-    params = os.path.join(config_directory, 'VLP16-velodyne_driver_node-params.yaml')
+    param_config = os.path.join(config_directory, 'VLP16-velodyne_driver_node-params.yaml')
+
+    # Load the parameters from YAML file
+    with open(param_config, 'r') as f:
+        params = yaml.safe_load(f)['velodyne_driver_node']['ros__parameters']
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
                                                    executable='velodyne_driver_node',
                                                    output='both',

--- a/velodyne_driver/launch/velodyne_driver_node-VLP32C-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLP32C-launch.py
@@ -33,6 +33,7 @@
 """Launch the velodyne driver node with default configuration."""
 
 import os
+import yaml
 
 import ament_index_python.packages
 import launch
@@ -43,7 +44,12 @@ def generate_launch_description():
     config_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory('velodyne_driver'),
         'config')
-    params = os.path.join(config_directory, 'VLP32C-velodyne_driver_node-params.yaml')
+    param_config = os.path.join(config_directory, 'VLP32C-velodyne_driver_node-params.yaml')
+
+    # Load the parameters from YAML file
+    with open(param_config, 'r') as f:
+        params = yaml.safe_load(f)['velodyne_driver_node']['ros__parameters']
+    
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
                                                    executable='velodyne_driver_node',
                                                    output='both',

--- a/velodyne_driver/launch/velodyne_driver_node-VLS128-launch.py
+++ b/velodyne_driver/launch/velodyne_driver_node-VLS128-launch.py
@@ -33,6 +33,7 @@
 """Launch the velodyne driver node with default configuration."""
 
 import os
+import yaml
 
 import ament_index_python.packages
 import launch
@@ -43,7 +44,11 @@ def generate_launch_description():
     config_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory('velodyne_driver'),
         'config')
-    params = os.path.join(config_directory, 'VLS128-velodyne_driver_node-params.yaml')
+    param_config = os.path.join(config_directory, 'VLS128-velodyne_driver_node-params.yaml')
+
+    # Load the parameters from YAML file
+    with open(param_config, 'r') as f:
+        params = yaml.safe_load(f)['velodyne_driver_node']['ros__parameters']
     velodyne_driver_node = launch_ros.actions.Node(package='velodyne_driver',
                                                    executable='velodyne_driver_node',
                                                    output='both',


### PR DESCRIPTION
This PR addresses a bug where the Velodyne driver node was incorrectly passing
the entire YAML path to the `parameters` argument rather than loading the
dictionary of parameters.

Changes:
* Updated `velodyne_driver_node-VLP16-launch.py` to load YAML using `yaml.safe_load`.
* Updated `velodyne_driver_node-VLP32C-launch.py` similarly.
* Updated `velodyne_driver_node-VLS128-launch.py` similarly.
* Verified that parameters are now loaded correctly under `velodyne_driver_node.ros__parameters`.

Tests:
* Launched each file in a ROS2 workspace and confirmed correct parameter loading.