### PR TITLE
switch to using yaml_cpp_vendor

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(velodyne_msgs REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 # Older versions of yaml-cpp have a target called "yaml-cpp",
@@ -160,6 +161,7 @@ ament_export_dependencies(
   tf2
   tf2_ros
   velodyne_msgs
+  yaml-cpp
 )
 ament_export_libraries(velodyne_rawdata velodyne_cloud_types)
 ament_export_targets(${PROJECT_NAME})

--- a/velodyne_pointcloud/package.xml
+++ b/velodyne_pointcloud/package.xml
@@ -29,7 +29,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>velodyne_msgs</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>


### PR DESCRIPTION
This change switches `velodyne_pointcloud` to use `yaml_cpp_vendor` so that it will use the same version of yaml-cpp as is used by the core ros packages (e.g. [camera_calibration_parsers](https://github.com/ros-perception/image_common/blob/rolling/camera_calibration_parsers/CMakeLists.txt#L19-L20), [rviz](https://github.com/ros2/rviz/blob/rolling/rviz_common/CMakeLists.txt#L56), etc.) This is important for folks who are building from source on platforms that may have a different system version than the version ros wants.
We are on Ubuntu 22.04 which comes with yaml-cpp 0.7 and using ros2 jazzy which wants 0.8. Mixing versions can cause problems downstream.