### PR TITLE
Migrate deprecated tf2/message_filters headers to .hpp

### DIFF
--- a/velodyne_driver/src/driver/driver.cpp
+++ b/velodyne_driver/src/driver/driver.cpp
@@ -37,7 +37,7 @@
 
 #include "velodyne_driver/driver.hpp"
 
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <chrono>
 #include <cmath>

--- a/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/datacontainerbase.hpp
@@ -33,12 +33,12 @@
 #ifndef VELODYNE_POINTCLOUD__DATACONTAINERBASE_HPP_
 #define VELODYNE_POINTCLOUD__DATACONTAINERBASE_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/buffer_core.h>
-#include <tf2/exceptions.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/buffer_core.hpp>
+#include <tf2/exceptions.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIRT.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/organized_cloudXYZIRT.hpp
@@ -33,7 +33,7 @@
 #ifndef VELODYNE_POINTCLOUD__ORGANIZED_CLOUDXYZIRT_HPP_
 #define VELODYNE_POINTCLOUD__ORGANIZED_CLOUDXYZIRT_HPP_
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <memory>
 #include <string>

--- a/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIRT.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/pointcloudXYZIRT.hpp
@@ -33,7 +33,7 @@
 #ifndef VELODYNE_POINTCLOUD__POINTCLOUDXYZIRT_HPP_
 #define VELODYNE_POINTCLOUD__POINTCLOUDXYZIRT_HPP_
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <memory>
 #include <string>

--- a/velodyne_pointcloud/include/velodyne_pointcloud/transform.hpp
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/transform.hpp
@@ -33,10 +33,10 @@
 #ifndef VELODYNE_POINTCLOUD__TRANSFORM_HPP_
 #define VELODYNE_POINTCLOUD__TRANSFORM_HPP_
 
-#include <message_filters/subscriber.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_listener.h>
+#include <message_filters/subscriber.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/message_filter.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <memory>
 #include <string>

--- a/velodyne_pointcloud/src/conversions/transform.cpp
+++ b/velodyne_pointcloud/src/conversions/transform.cpp
@@ -32,8 +32,8 @@
 
 #include "velodyne_pointcloud/transform.hpp"
 
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/message_filter.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 #include <cmath>
 #include <functional>

--- a/velodyne_pointcloud/src/lib/organized_cloudXYZIRT.cpp
+++ b/velodyne_pointcloud/src/lib/organized_cloudXYZIRT.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <cmath>
 #include <memory>

--- a/velodyne_pointcloud/src/lib/pointcloudXYZIRT.cpp
+++ b/velodyne_pointcloud/src/lib/pointcloudXYZIRT.cpp
@@ -30,7 +30,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <memory>
 #include <string>

--- a/velodyne_pointcloud/tests/test_row_step.cpp
+++ b/velodyne_pointcloud/tests/test_row_step.cpp
@@ -32,7 +32,7 @@
 
 #include <gtest/gtest.h>
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <memory>
 


### PR DESCRIPTION
The `.h` headers for `tf2`, `tf2_ros` and `message_filters` were deprecated in favour of `.hpp` versions and have since been **removed on Rolling**, so `velodyne_pointcloud` / `velodyne_driver` currently fail to build there (this is what surfaced while packaging velodyne for [RoboStack](https://github.com/RoboStack)).

The `.hpp` headers are available on **all currently supported distros** — I verified `buffer_core`, `exceptions`, `LinearMath/Quaternion`, `LinearMath/Vector3`, `tf2_ros/{buffer,transform_listener,message_filter}` and `message_filters/subscriber` all exist as `.hpp` on Humble, Jazzy and Kilted — so the switch is unconditional and needs no version guards.

Changes are limited to swapping the include extensions; no code/logic changes. Covers `velodyne_pointcloud` and the one remaining include in `velodyne_driver`.